### PR TITLE
Hint desktop-save-mode for child frame

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -255,6 +255,7 @@ Set to nil in order to disable confirmation."
     (set-frame-parameter
      corfu--frame 'background-color
      (face-attribute 'corfu-background :background))
+    (set-frame-parameter corfu--frame 'desktop-dont-save t)
     (set-window-buffer (frame-root-window corfu--frame) buffer)
     ;; XXX Make the frame invisible before moving the popup from above to below
     ;; the line in order to avoid flicker.


### PR DESCRIPTION
By default, the `corfu--frame` child frame is being persisted across sessions saved by `desktop-save-mode`, leading to a random / non-dismissible corfu popup when I launch emacs.

I'm currently using the following advice to prevent this from happening:

```emacs-lisp
  (defun dont-save-frame (orig-fun &rest args)
    "Add the `desktop-dont-save' parameter to the frame."
    (apply orig-fun args)
    (when corfu--frame (set-frame-parameter corfu--frame 'desktop-dont-save t)))
  (advice-add 'corfu--child-frame :around #'dont-save-frame)
```

This PR makes this change more directly.