### PR TITLE
Allow commit predicate function to run even without selection

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -691,7 +691,8 @@ completion began less than that number of seconds ago."
 (defun corfu--pre-command ()
   "Insert selected candidate unless command is marked to continue completion."
   (add-hook 'window-configuration-change-hook #'corfu-quit)
-  (unless (or (< corfu--index 0) (corfu--match-symbol-p corfu-continue-commands this-command))
+  (unless (or (and (< corfu--index 0) (not (functionp corfu-commit-predicate)))
+	      (corfu--match-symbol-p corfu-continue-commands this-command))
     (if (if (functionp corfu-commit-predicate)
             (funcall corfu-commit-predicate)
           corfu-commit-predicate)


### PR DESCRIPTION
This is a simple proof of principle that allows the commit predicate function to auto-complete even the "implicit" selection of the first candidate (i.e. when there is no selection).  So far I've used it with success to auto-commit the first candidate if it is an exact match, or if there is only a single candidate. The former eliminates the source of "unwanted No match" popups lingering.

If we go with something like this, it should be emphasized in the docs that the predicate should "normally" return `nil` when there is no selection.  A further generalization would be to allow such a function to return `quit`, meaning quit the completion without inserting anything.  The default of `t` maintains the original behavior.