### PR TITLE
Implement corfu-align-annotations for both prefix and suffix

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -597,10 +597,10 @@ CAND is either a string or 3 part list of (cand prefix suffix).
 If `corfu-align-annotations' is non-nil, Pad prefix to a total
 width of PREF-WIDTH and right-align the suffix for a total width
 of WIDTH characters (not including prefix), truncating the
-suffix (only) if necessary.  If CURRENT is non-nil, apply the
-face `corfu-current' to the full string.  Insert string MARGIN on
-left and between prefix & candidate, and include RIGHT-MARGIN (if
-non-nil)."
+candidate + suffix if necessary.  If CURRENT is non-nil, apply
+the face `corfu-current' to the full string.  Insert string
+MARGIN on left and between prefix & candidate, and include
+RIGHT-MARGIN (if non-nil)."
   (let ((str
 	 (pcase cand
 	   (`(,cand ,prefix ,suffix)
@@ -609,10 +609,7 @@ non-nil)."
 		  (cw (string-width cand))
 		  (sw (string-width suffix))
 		  (prefix-margin margin)
-		  prefix-pad suffix-pad)
-	      (if (> (+ cw sw) width)
-		  (setq suffix (truncate-string-to-width
-				suffix sw (- (+ sw cw) width))))
+		  prefix-pad suffix-pad candsuff)
 	      (add-face-text-property
 	       0 (length suffix) 'corfu-annotations 'append suffix)
 	      (when corfu-align-annotations
@@ -623,9 +620,13 @@ non-nil)."
 		     0 (length prefix-pad) face 'append prefix-pad)
 		    (setq prefix-margin (copy-sequence prefix-margin))
 		    (add-face-text-property 0 1 face nil prefix-margin)))
+	      (setq candsuff (concat cand suffix-pad suffix))
+	      (if (> (length candsuff) width)
+		  (setq candsuff (truncate-string-to-width candsuff width)))
 	      (apply #'concat
-		     prefix-margin prefix-pad prefix (if (> pref-width 0) prefix-margin)
-		     cand suffix-pad suffix right-margin)))
+		     prefix-margin prefix-pad prefix
+		     (if (> pref-width 0) prefix-margin)
+		     candsuff right-margin)))
 	   (_ (apply #'concat margin cand right-margin)))))
     (if current (add-face-text-property
 		 0 (length str) 'corfu-current 'append str))

--- a/corfu.el
+++ b/corfu.el
@@ -376,6 +376,25 @@ completion began less than that number of seconds ago."
     (set-frame-size corfu--frame width height t)
     (make-frame-visible corfu--frame)))
 
+(defsubst corfu--max-cand-widths (cands)
+  "Return maximum string widths for the given candidates CANDS.
+CANDS is a list of strings, or of lists with elements (candidate
+prefix suffix).  Returns a cons cell 
+
+   (max(prefix) . max(cand+suffix)) 
+
+containing the maximum prefix width and maximum of candiate +
+suffix width, in this order."
+  (let ((widths (mapcar (lambda (cand)
+			  (if (consp cand)
+			      (cons (string-width (cadr cand)) ; prefix
+				    (+ (string-width (car cand))
+				       (string-width (caddr cand))))
+			    (cons 0 (string-width cand)))) ; only candidate
+			cands)))
+    (cons (apply #'max (mapcar 'car widths))
+	  (apply #'max (mapcar 'cdr widths)))))
+
 (defun corfu--popup-show (pos cands &optional curr lo bar)
   "Show CANDS as popup at POS, with CURR highlighted and scrollbar from LO to LO+BAR."
   (let* ((ch (default-line-height))
@@ -632,25 +651,6 @@ RIGHT-MARGIN (if non-nil)."
 		 0 (length str) 'corfu-current 'append str))
     str))
 
-(defsubst corfu--max-cand-widths (cands)
-  "Return maximum string widths for the given candidates CANDS.
-CANDS is a list of strings, or of lists with elements (candidate
-prefix suffix).  Returns a cons cell 
-
-   (max(prefix) . max(cand+suffix)) 
-
-containing the maximum prefix width and maximum of candiate +
-suffix width, in this order."
-  (let ((widths (mapcar (lambda (cand)
-			  (if (consp cand)
-			      (cons (string-width (cadr cand)) ; prefix
-				    (+ (string-width (car cand))
-				       (string-width (caddr cand))))
-			    (cons 0 (string-width cand)))) ; only candidate
-			cands)))
-    (cons (apply #'max (mapcar 'car widths))
-	  (apply #'max (mapcar 'cdr widths)))))
-		     
 (defun corfu--show-candidates (beg end str)
   "Update display given BEG, END and STR."
   (let* ((start (min (max 0 (- corfu--index (/ corfu-count 2)))


### PR DESCRIPTION
This implements annotation alignment in corfu, controlled by the custom boolean `corfu-align-annotations`.  Prefixes (if present) are left-padded to the maximum displayed prefix width.  Suffixes (if present) are padded to right-align with the full content width.  Truncation resulting from overflowing the maximum width impacts suffixes first.

All formatting, styling and  alignment (aside from the final bar/margin) has been moved to the function `corfu--format-candidate`, which is now called later, in `corfu--popup-show`.  Until this point, all candidate list items can be strings or `(candidate prefix suffix)` lists.  Note that, when aligning, any pre-existing face information on prefix text is preserved by the prefix-padding, and copied to the surrounding margin padding (margin is placed between prefix and candidate).

This uses simple space-padding for alignment, which means it works correctly for fixed-width content only. Should we desire to support arbitrary variable-pitch fonts/glpyhs/etc. updating  `corfu--format-candidate` and `corfu--max-cand-widths` should be all that is required (presumably using `window-text-pixel-size` in a temporary buffer, or the hidden child frame's window buffer).