### PR TITLE
Add kind formatter

### DIFF
--- a/README.org
+++ b/README.org
@@ -49,6 +49,7 @@
   - Show candidate documentation/signature string in the echo area.
   - Deprecated candidates are crossed out in the display.
   - Support for annotations (~annotation-function~, ~affixation-function~).
+  - Icons can be provided by an external package via ~corfu-kind-formatter~.
 
 * Configuration
 
@@ -158,7 +159,6 @@
   - Corfu falls back to the default Completion buffer on non-graphical displays,
     since Corfu requires child frames.
   - The abort handling could be improved, for example the input could be undone.
-  - Some Company metadata extensions are not supported (~company-kind~, ~company-match~).
   - No sorting by history, since ~completion-at-point~ does not
     maintain a history (See branch =history= for a possible solution).
 


### PR DESCRIPTION
@jdtsmith I made a few more simplifications. The prefix and suffix are not trimmed anymore. I could now add this kind formatter which would make integration with icon libraries a bit easier (but not by much, your affixation approach would still work perfectly fine). Furthermore separate margin configuration for the and right side is missing. Then you could set the margin left to zero and your 2x1 icons would be nicely aligned. Please let me know what you think.