### PR TITLE
Bind [return] instead

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -211,7 +211,7 @@ The completion backend can override this with
     (define-key map "\en" #'corfu-next)
     (define-key map "\ep" #'corfu-previous)
     (define-key map "\C-g" #'corfu-quit)
-    (define-key map "\r" #'corfu-insert)
+    (define-key map [return] #'corfu-insert)
     (define-key map "\t" #'corfu-complete)
     (define-key map "\eg" #'corfu-show-location)
     (define-key map "\eh" #'corfu-show-documentation)


### PR DESCRIPTION
Binding to the key-code 13 (`C-m`) takes lower precedence than the vector key `[return]`. If a mode map bind the latter, `corfu-input` is not invoked by hitting Return when corfu is popped up.  See http://xahlee.info/emacs/emacs/emacs_key_notation_return_vs_RET.html.  

Try:

``` emacs-lisp
(local-set-key [return] (lambda () (interactive) (message "Overridden!")))
```

in `*scratch*` then use corfu there.