### PR TITLE
Handle orderless separator for prefix sort

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -549,7 +549,9 @@ A scroll bar is displayed from LO to LO+BAR."
 
 (defun corfu--move-prefix-candidates-to-front (field candidates)
   "Move CANDIDATES which match prefix of FIELD to the beginning."
-  (let* ((word (replace-regexp-in-string " .*" "" field))
+  (let* ((word (if (boundp 'orderless-component-separator)
+		   (car (split-string field orderless-component-separator))
+		 (replace-regexp-in-string " .*" "" field)))
          (len (length word)))
     (corfu--partition!
      candidates


### PR DESCRIPTION
This preserves prefix-sorting when an orderless separator is included in the input.

When orderless is configured with a component separator that is _not_ a space, `corfu-move-prefix-candidates-to-front` can change the sort order after that prefix is typed, which is unexpected.  Here's an example with `*` as the separator:

```elisp
(foo  ; -> footnote-mode ewoc--footer...
(foo* ; -> ewoc--footer footnote-mode...
```

This is because `corfu-move-prefix-candidates-to-front` strips spaces from the input before checking its prefix status, but not other separators.  Since this may be a common way to use orderless+corfu, it may be worth special-casing, as has been done for orderless highlighting.
