### PR TITLE
Use separator character for boundary quit logic and prefix sort

### DIFF
--- a/README.org
+++ b/README.org
@@ -242,6 +242,10 @@ Then, when a new orderless component is desired, simply use =M-SPC=
 input, and arbitrary orderless search terms and new separators can be entered
 thereafter.
 
+Note that ~corfu-separator~ replaced and obsoleted ~corfu-quit-at-boundary~. If you
+want to restore the old behavior of ~corfu-quit-at-boundary=t~ you can bind
+~corfu-insert-separator~ to =SPC= in ~corfu-map~.
+
  #+begin_src emacs-lisp
    (use-package corfu
      ;; Orderless customizations
@@ -294,6 +298,7 @@ moves to the next candidate and further input will then commit the selection.
   - =RET= -> ~corfu-insert~
   - =M-g= -> ~corfu-show-location~
   - =M-h= -> ~corfu-show-documentation~
+  - =M-SPC= -> ~corfu-insert-separator~
   - =C-g= -> ~corfu-quit~
   - ~keyboard-escape-quit~ -> ~corfu-reset~
 

--- a/README.org
+++ b/README.org
@@ -224,11 +224,23 @@ sane Eshell experience.*
 
 ** Orderless auto-completion
 
-[[https://github.com/oantolin/orderless][Orderless]] is an advanced completion style that supports multi-component search filters separated by a configurable character (space, by default).  Normally, entering characters like space which lie outside the completion region boundaries (words, typically) causes corfu to quit.  This behavior is very helpful with auto-completion, which may pop-up when not desired, e.g. on entering a new variable name.  Just keep typing and corfu will get out of the way.  
+[[https://github.com/oantolin/orderless][Orderless]] is an advanced completion style that supports multi-component search
+filters separated by a configurable character (space, by default). Normally,
+entering characters like space which lie outside the completion region
+boundaries (words, typically) causes corfu to quit. This behavior is very
+helpful with auto-completion, which may pop-up when not desired, e.g. on
+entering a new variable name. Just keep typing and corfu will get out of the
+way.
 
-But orderless search terms can contain any characters; they are regular expressions. To use orderless in the buffer with ~corfu-auto~, set ~corfu-separator-char~ (a space, by default) to the primary character of your orderless component separator.
+But orderless search terms can contain any characters; they are regular
+expressions. To use orderless in the buffer with ~corfu-auto~, set
+~corfu-separator-char~ (a space, by default) to the primary character of your
+orderless component separator.
 
-Then, when a new orderless component is desired, simply use =M-SPC= (~corfu-insert-separator-char~) to enter the /first/ component separator in the input, and arbitrary orderless search terms and new separators can be entered thereafter.  
+Then, when a new orderless component is desired, simply use =M-SPC=
+(~corfu-insert-separator-char~) to enter the /first/ component separator in the
+input, and arbitrary orderless search terms and new separators can be entered
+thereafter.
 
  #+begin_src emacs-lisp
    (use-package corfu
@@ -241,7 +253,7 @@ Then, when a new orderless component is desired, simply use =M-SPC= (~corfu-inse
      ;;	   ("M-SPC" . corfu-insert-separator-char))
      :init
      (corfu-global-mode))
- #+end_src    
+ #+end_src
 
 ** TAB-and-Go completion
 

--- a/README.org
+++ b/README.org
@@ -46,7 +46,7 @@
   - The selected candidate automatically committed on further input by default
     (configurable via ~corfu-commit-predicate~).
   - The [[https://github.com/oantolin/orderless][Orderless]] completion style is supported. The filter string can contain
-    arbitrary characters, including spaces, if ~corfu-quit-at-boundary~ is nil.
+    arbitrary characters, including spaces, if ~corfu-separator-char~ is configured to match the orderless separator, and a special key is used to insert the first separator.
   - Deferred completion style highlighting for performance.
   - Jumping to location/documentation of current candidate.
   - Show candidate documentation/signature string in the echo area.
@@ -77,13 +77,15 @@
       ;; (corfu-cycle t)                ;; Enable cycling for `corfu-next/previous'
       ;; (corfu-auto t)                 ;; Enable auto completion
       ;; (corfu-commit-predicate nil)   ;; Do not commit selected candidates on next input
-      ;; (corfu-quit-at-boundary t)     ;; Automatically quit at word boundary
+      ;; (corfu-separator-char ? )      ;; Inihibit quit at word boundary with this char
       ;; (corfu-quit-no-match t)        ;; Automatically quit if there is no match
       ;; (corfu-preview-current nil)    ;; Disable current candidate preview
       ;; (corfu-preselect-first nil)    ;; Disable candidate preselection
       ;; (corfu-echo-documentation nil) ;; Disable documentation in the echo area
       ;; (corfu-scroll-margin 5)        ;; Use scroll margin
 
+      ;; :bind (corfu-map               ;; Bind a command to insert 1st separator char
+      ;;        ("M-SPC" . corfu-insert-separator-char))
       ;; You may want to enable Corfu only for certain modes.
       ;; :hook ((prog-mode . corfu-mode)
       ;;        (shell-mode . corfu-mode)
@@ -104,14 +106,14 @@
       ;; (setq orderless-style-dispatchers '(+orderless-dispatch)
       ;;       orderless-component-separator #'orderless-escapable-split-on-space)
       (setq completion-styles '(orderless)
-            completion-category-defaults nil
-            completion-category-overrides '((file (styles . (partial-completion))))))
+	    completion-category-defaults nil
+	    completion-category-overrides '((file (styles . (partial-completion))))))
 
     ;; Use dabbrev with Corfu!
     (use-package dabbrev
       ;; Swap M-/ and C-M-/
       :bind (("M-/" . dabbrev-completion)
-             ("C-M-/" . dabbrev-expand)))
+	     ("C-M-/" . dabbrev-expand)))
 
     ;; A few more useful configurations...
     (use-package emacs
@@ -144,14 +146,13 @@
   #+begin_src emacs-lisp
     ;; Enable auto completion and eager quitting
     (setq corfu-auto t
-          corfu-quit-at-boundary t
           corfu-quit-no-match t)
   #+end_src
 
   In general, I recommend to experiment a bit with the various settings and key
   bindings to find a configuration which works for you. There is no one size
   fits all solution. Some people like auto completion, some like manual
-  completion, some want to cycle with TAB or and some with the arrow keys...
+  completion, some want to cycle with TAB and some with the arrow keys...
 
 ** Completing with Corfu in the minibuffer
 
@@ -190,13 +191,12 @@ completion UI, the following snippet should yield the desired result.
 ** Completing with Corfu in the Shell or Eshell
 
 When completing in the Eshell I recommend conservative local settings, no auto
-completion, quitting at boundary and quitting if there is no match.
+completion, and quitting if there is no match.
 
 #+begin_src emacs-lisp
   (add-hook 'eshell-mode-hook
             (lambda ()
-              (setq-local corfu-quit-at-boundary t
-                          corfu-quit-no-match t
+              (setq-local corfu-quit-no-match t
                           corfu-auto nil)
               (corfu-mode)))
 #+end_src
@@ -223,6 +223,23 @@ sane Eshell experience.*
   ;; and behaves as a pure `completion-at-point-function'.
   (advice-add 'pcomplete-completions-at-point :around #'cape-wrap-purify)
 #+end_src
+
+** Orderless auto-completion
+
+[[https://github.com/oantolin/orderless][Orderless]] is an advanced completion style that supports multi-component search filters separated by a configurable character (space, by default).  To use orderless effectively in the buffer with ~corfu-auto~, while still normally quitting at completion boundaries, bind the command ~corfu-insert-separator-char~ to a convenient key in Corfu's keymap, and set ~corfu-separator-char~ (a space, by default) to the primary character of your orderless component separator.  Simply enter this key-binding for the /first/ component separator, and arbitrary orderless search terms can be entered thereafter. 
+
+ #+begin_src emacs-lisp
+   (use-package corfu
+     ;; Orderless customizations
+     :custom
+     (corfu-auto t)
+     ;; (corfu-separator-char ?_) ;; Set to orderless separator, if not using space
+     :bind
+     (:map corfu-map
+	   ("M-SPC" . corfu-insert-separator-char))
+     :init
+     (corfu-global-mode))
+ #+end_src    
 
 ** TAB-and-Go completion
 
@@ -275,7 +292,7 @@ moves to the next candidate and further input will then commit the selection.
 
   - [[https://github.com/oantolin/orderless][Orderless]]: Corfu supports completion styles,
     including the advanced [[https://github.com/oantolin/orderless][Orderless]] completion style, where the filtering
-    expressions are separated by spaces (see ~corfu-quit-at-boundary~).
+    expressions are separated by spaces or another character (see ~corfu-separator-char~).
 
   - [[https://github.com/minad/cape][Cape]]: I collect additional Capf backends and =completion-in-region= commands
     in my [[https://github.com/minad/cape][Cape]] package. The package provides a file path, a dabbrev completion

--- a/README.org
+++ b/README.org
@@ -106,14 +106,14 @@
       ;; (setq orderless-style-dispatchers '(+orderless-dispatch)
       ;;       orderless-component-separator #'orderless-escapable-split-on-space)
       (setq completion-styles '(orderless)
-	    completion-category-defaults nil
-	    completion-category-overrides '((file (styles . (partial-completion))))))
+            completion-category-defaults nil
+            completion-category-overrides '((file (styles . (partial-completion))))))
 
     ;; Use dabbrev with Corfu!
     (use-package dabbrev
       ;; Swap M-/ and C-M-/
       :bind (("M-/" . dabbrev-completion)
-	     ("C-M-/" . dabbrev-expand)))
+             ("C-M-/" . dabbrev-expand)))
 
     ;; A few more useful configurations...
     (use-package emacs

--- a/README.org
+++ b/README.org
@@ -77,7 +77,7 @@
       ;; (corfu-cycle t)                ;; Enable cycling for `corfu-next/previous'
       ;; (corfu-auto t)                 ;; Enable auto completion
       ;; (corfu-commit-predicate nil)   ;; Do not commit selected candidates on next input
-      ;; (corfu-separator ?\s)     ;; Inihibit quit at word boundary with this char
+      ;; (corfu-separator ?\s)          ;; Orderless field separator
       ;; (corfu-quit-no-match t)        ;; Automatically quit if there is no match
       ;; (corfu-preview-current nil)    ;; Disable current candidate preview
       ;; (corfu-preselect-first nil)    ;; Disable candidate preselection

--- a/README.org
+++ b/README.org
@@ -46,7 +46,7 @@
   - The selected candidate automatically committed on further input by default
     (configurable via ~corfu-commit-predicate~).
   - The [[https://github.com/oantolin/orderless][Orderless]] completion style is supported. The filter string can contain
-    arbitrary characters, including spaces, if ~corfu-separator-char~ is configured to match the orderless separator, and a special key is used to insert the first separator.
+    arbitrary characters, including spaces, if ~corfu-separator-char~ is configured (try =M-SPC=).
   - Deferred completion style highlighting for performance.
   - Jumping to location/documentation of current candidate.
   - Show candidate documentation/signature string in the echo area.
@@ -77,15 +77,13 @@
       ;; (corfu-cycle t)                ;; Enable cycling for `corfu-next/previous'
       ;; (corfu-auto t)                 ;; Enable auto completion
       ;; (corfu-commit-predicate nil)   ;; Do not commit selected candidates on next input
-      ;; (corfu-separator-char ? )      ;; Inihibit quit at word boundary with this char
+      ;; (corfu-separator-char ?\s)     ;; Inihibit quit at word boundary with this char
       ;; (corfu-quit-no-match t)        ;; Automatically quit if there is no match
       ;; (corfu-preview-current nil)    ;; Disable current candidate preview
       ;; (corfu-preselect-first nil)    ;; Disable candidate preselection
       ;; (corfu-echo-documentation nil) ;; Disable documentation in the echo area
       ;; (corfu-scroll-margin 5)        ;; Use scroll margin
 
-      ;; :bind (corfu-map               ;; Bind a command to insert 1st separator char
-      ;;        ("M-SPC" . corfu-insert-separator-char))
       ;; You may want to enable Corfu only for certain modes.
       ;; :hook ((prog-mode . corfu-mode)
       ;;        (shell-mode . corfu-mode)
@@ -226,7 +224,11 @@ sane Eshell experience.*
 
 ** Orderless auto-completion
 
-[[https://github.com/oantolin/orderless][Orderless]] is an advanced completion style that supports multi-component search filters separated by a configurable character (space, by default).  To use orderless effectively in the buffer with ~corfu-auto~, while still normally quitting at completion boundaries, bind the command ~corfu-insert-separator-char~ to a convenient key in Corfu's keymap, and set ~corfu-separator-char~ (a space, by default) to the primary character of your orderless component separator.  Simply enter this key-binding for the /first/ component separator, and arbitrary orderless search terms can be entered thereafter. 
+[[https://github.com/oantolin/orderless][Orderless]] is an advanced completion style that supports multi-component search filters separated by a configurable character (space, by default).  Normally, entering characters like space which lie outside the completion region boundaries (words, typically) causes corfu to quit.  This behavior is very helpful with auto-completion, which may pop-up when not desired, e.g. on entering a new variable name.  Just keep typing and corfu will get out of the way.  
+
+But orderless search terms can contain any characters; they are regular expressions. To use orderless in the buffer with ~corfu-auto~, set ~corfu-separator-char~ (a space, by default) to the primary character of your orderless component separator.
+
+Then, when a new orderless component is desired, simply use =M-SPC= (~corfu-insert-separator-char~) to enter the /first/ component separator in the input, and arbitrary orderless search terms and new separators can be entered thereafter.  
 
  #+begin_src emacs-lisp
    (use-package corfu
@@ -235,8 +237,8 @@ sane Eshell experience.*
      (corfu-auto t)
      ;; (corfu-separator-char ?_) ;; Set to orderless separator, if not using space
      :bind
-     (:map corfu-map
-	   ("M-SPC" . corfu-insert-separator-char))
+     ;; (:map corfu-map  ;; Another key binding can be used, such as S-SPC
+     ;;	   ("M-SPC" . corfu-insert-separator-char))
      :init
      (corfu-global-mode))
  #+end_src    

--- a/README.org
+++ b/README.org
@@ -46,7 +46,7 @@
   - The selected candidate automatically committed on further input by default
     (configurable via ~corfu-commit-predicate~).
   - The [[https://github.com/oantolin/orderless][Orderless]] completion style is supported. The filter string can contain
-    arbitrary characters, including spaces, if ~corfu-separator-char~ is configured (try =M-SPC=).
+    arbitrary characters, including spaces, if ~corfu-separator~ is configured (try =M-SPC=).
   - Deferred completion style highlighting for performance.
   - Jumping to location/documentation of current candidate.
   - Show candidate documentation/signature string in the echo area.
@@ -77,7 +77,7 @@
       ;; (corfu-cycle t)                ;; Enable cycling for `corfu-next/previous'
       ;; (corfu-auto t)                 ;; Enable auto completion
       ;; (corfu-commit-predicate nil)   ;; Do not commit selected candidates on next input
-      ;; (corfu-separator-char ?\s)     ;; Inihibit quit at word boundary with this char
+      ;; (corfu-separator ?\s)     ;; Inihibit quit at word boundary with this char
       ;; (corfu-quit-no-match t)        ;; Automatically quit if there is no match
       ;; (corfu-preview-current nil)    ;; Disable current candidate preview
       ;; (corfu-preselect-first nil)    ;; Disable candidate preselection
@@ -234,11 +234,11 @@ way.
 
 But orderless search terms can contain any characters; they are regular
 expressions. To use orderless in the buffer with ~corfu-auto~, set
-~corfu-separator-char~ (a space, by default) to the primary character of your
+~corfu-separator~ (a space, by default) to the primary character of your
 orderless component separator.
 
 Then, when a new orderless component is desired, simply use =M-SPC=
-(~corfu-insert-separator-char~) to enter the /first/ component separator in the
+(~corfu-insert-separator~) to enter the /first/ component separator in the
 input, and arbitrary orderless search terms and new separators can be entered
 thereafter.
 
@@ -247,10 +247,10 @@ thereafter.
      ;; Orderless customizations
      :custom
      (corfu-auto t)
-     ;; (corfu-separator-char ?_) ;; Set to orderless separator, if not using space
+     ;; (corfu-separator ?_) ;; Set to orderless separator, if not using space
      :bind
      ;; (:map corfu-map  ;; Another key binding can be used, such as S-SPC
-     ;;	   ("M-SPC" . corfu-insert-separator-char))
+     ;;	   ("M-SPC" . corfu-insert-separator))
      :init
      (corfu-global-mode))
  #+end_src
@@ -306,7 +306,7 @@ moves to the next candidate and further input will then commit the selection.
 
   - [[https://github.com/oantolin/orderless][Orderless]]: Corfu supports completion styles,
     including the advanced [[https://github.com/oantolin/orderless][Orderless]] completion style, where the filtering
-    expressions are separated by spaces or another character (see ~corfu-separator-char~).
+    expressions are separated by spaces or another character (see ~corfu-separator~).
 
   - [[https://github.com/minad/cape][Cape]]: I collect additional Capf backends and =completion-in-region= commands
     in my [[https://github.com/minad/cape][Cape]] package. The package provides a file path, a dabbrev completion

--- a/corfu.el
+++ b/corfu.el
@@ -93,10 +93,11 @@ The character used for separating components in the input.
 Useful for multi-component completion styles such as orderless.
 To use, bind `corfu-insert-separator-char' to a convenient
 key (e.g. M-SPC) in corfu-map, and use this binding to enter the
-first separator character.  Both this command and the presence of
-the separator character within the input will inhibit quitting on
-completion boundaries."
-    :type 'character)
+first separator character.  If this char is non-nil, both this
+command and the presence of the separator character within the
+input will inhibit quitting at completion boundaries.  If nil,
+always quit at boundaries."
+  :type '(choice (const nil) 'character))
 
 (defcustom corfu-quit-no-match 1.0
   "Automatically quit if no matching candidate is found.
@@ -852,12 +853,12 @@ there hasn't been any input, then quit."
   "Return t if a candidate is selected and previewed."
   (and corfu-preview-current (/= corfu--index corfu--preselect)))
 
-
 (defun corfu-insert-separator-char ()
   "Insert a separator character, inhibiting quit on completion boundary.
 Bind to a convenient key in corfu-map."
   (interactive)
-  (insert corfu-separator-char))
+  (if corfu-separator-char (insert corfu-separator-char)
+    (user-error "Corfu separator character is nil.")))
 
 (defun corfu--post-command ()
   "Refresh Corfu after last command."
@@ -872,9 +873,10 @@ Bind to a convenient key in corfu-map."
                       (save-excursion
                         (goto-char beg)
                         (<= (line-beginning-position) pt (line-end-position)))
-                      (or (eq this-command 'corfu-insert-separator-char)
-                          (seq-contains-p (car corfu--input) corfu-separator-char)
-                          (funcall completion-in-region-mode--predicate))))
+                      (or (and corfu-separator-char
+			       (or (eq this-command 'corfu-insert-separator-char)
+				   (seq-contains-p (car corfu--input) corfu-separator-char)))
+			  (funcall completion-in-region-mode--predicate))))
            (corfu--update)
            t)))
       (corfu-quit)))

--- a/corfu.el
+++ b/corfu.el
@@ -83,18 +83,19 @@ The value should lie between 0 and corfu-count/2."
   "Preselect first candidate."
   :type 'boolean)
 
-(make-obsolete 'corfu-quit-at-boundary
-               "see the new `corfu-separator-char' customization."
-               "0.19")
+(make-obsolete
+ 'corfu-quit-at-boundary
+ "See the new `corfu-separator' customization."
+ "0.19")
 
-(defcustom corfu-separator-char ?\s
+(defcustom corfu-separator ?\s
   "Component separator character.
 The character used for separating components in the input.  If
 non-nil, the presence of this separator character will inhibit
 quitting at completion boundaries, so that any further characters
 can be entered.  If nil, always quit at completion boundaries.
 To enter the first separator character, call
-`corfu-insert-separator-char' (bound to M-SPC by default).
+`corfu-insert-separator' (bound to M-SPC by default).
 Useful for multi-component completion styles such as orderless."
   :type '(choice (const nil) 'character))
 
@@ -224,7 +225,7 @@ The completion backend can override this with
     (define-key map "\t" #'corfu-complete)
     (define-key map "\eg" #'corfu-show-location)
     (define-key map "\eh" #'corfu-show-documentation)
-    (define-key map "\e " #'corfu-insert-separator-char)
+    (define-key map "\e " #'corfu-insert-separator)
     map)
   "Corfu keymap used when popup is shown.")
 
@@ -569,7 +570,7 @@ A scroll bar is displayed from LO to LO+BAR."
 (defun corfu--move-prefix-candidates-to-front (field candidates)
   "Move CANDIDATES which match prefix of FIELD to the beginning."
   (let* ((word (substring field 0
-                          (seq-position field corfu-separator-char)))
+                          (seq-position field corfu-separator)))
          (len (length word)))
     (corfu--partition!
      candidates
@@ -853,11 +854,11 @@ there hasn't been any input, then quit."
   "Return t if a candidate is selected and previewed."
   (and corfu-preview-current (/= corfu--index corfu--preselect)))
 
-(defun corfu-insert-separator-char ()
+(defun corfu-insert-separator ()
   "Insert a separator character, inhibiting quit on completion boundary."
   (interactive)
-  (if corfu-separator-char (insert corfu-separator-char)
-    (user-error "Corfu separator character is nil.")))
+  (unless corfu-separator (error "`corfu-separator' character is nil"))
+  (insert corfu-separator))
 
 (defun corfu--post-command ()
   "Refresh Corfu after last command."
@@ -872,10 +873,10 @@ there hasn't been any input, then quit."
                       (save-excursion
                         (goto-char beg)
                         (<= (line-beginning-position) pt (line-end-position)))
-                      (or (and corfu-separator-char ; command enables separator insertion
-			       (or (eq this-command 'corfu-insert-separator-char)
-				   (seq-contains-p  ; with separator, any further chars allowed
-				    (car corfu--input) corfu-separator-char)))
+                      (or (and corfu-separator ;; command enables separator insertion
+			       (or (eq this-command #'corfu-insert-separator)
+				   (seq-contains-p  ;; with separator, any further chars allowed
+				    (car corfu--input) corfu-separator)))
 			  (funcall completion-in-region-mode--predicate))))
            (corfu--update)
            t)))

--- a/corfu.el
+++ b/corfu.el
@@ -89,14 +89,13 @@ The value should lie between 0 and corfu-count/2."
 
 (defcustom corfu-separator-char ?\s 
   "Component separator character.
-The character used for separating components in the input.
-Useful for multi-component completion styles such as orderless.
-To use, bind `corfu-insert-separator-char' to a convenient
-key (e.g. M-SPC) in corfu-map, and use this binding to enter the
-first separator character.  If this char is non-nil, both this
-command and the presence of the separator character within the
-input will inhibit quitting at completion boundaries.  If nil,
-always quit at boundaries."
+The character used for separating components in the input.  If
+non-nil, the presence of this separator character will inhibit
+quitting at completion boundaries, so that any further characters
+can be entered.  If nil, always quit at completion boundaries.
+To enter the first separator character, call
+`corfu-insert-separator-char' (bound to M-SPC by default).
+Useful for multi-component completion styles such as orderless."
   :type '(choice (const nil) 'character))
 
 (defcustom corfu-quit-no-match 1.0
@@ -225,6 +224,7 @@ The completion backend can override this with
     (define-key map "\t" #'corfu-complete)
     (define-key map "\eg" #'corfu-show-location)
     (define-key map "\eh" #'corfu-show-documentation)
+    (define-key map "\e " #'corfu-insert-separator-char)
     map)
   "Corfu keymap used when popup is shown.")
 
@@ -854,8 +854,7 @@ there hasn't been any input, then quit."
   (and corfu-preview-current (/= corfu--index corfu--preselect)))
 
 (defun corfu-insert-separator-char ()
-  "Insert a separator character, inhibiting quit on completion boundary.
-Bind to a convenient key in corfu-map."
+  "Insert a separator character, inhibiting quit on completion boundary."
   (interactive)
   (if corfu-separator-char (insert corfu-separator-char)
     (user-error "Corfu separator character is nil.")))

--- a/corfu.el
+++ b/corfu.el
@@ -567,8 +567,8 @@ A scroll bar is displayed from LO to LO+BAR."
 
 (defun corfu--move-prefix-candidates-to-front (field candidates)
   "Move CANDIDATES which match prefix of FIELD to the beginning."
-  (let* ((word (replace-regexp-in-string
-                (format "[%c].*" corfu-separator-char) "" field))
+  (let* ((word (substring field 0
+                          (seq-position field corfu-separator-char)))
          (len (length word)))
     (corfu--partition!
      candidates
@@ -854,7 +854,7 @@ there hasn't been any input, then quit."
 
 
 (defun corfu-insert-separator-char ()
-  "Insert a separator character and inhibit quit on completion boundary.
+  "Insert a separator character, inhibiting quit on completion boundary.
 Bind to a convenient key in corfu-map."
   (interactive)
   (insert corfu-separator-char))

--- a/corfu.el
+++ b/corfu.el
@@ -873,9 +873,10 @@ Bind to a convenient key in corfu-map."
                       (save-excursion
                         (goto-char beg)
                         (<= (line-beginning-position) pt (line-end-position)))
-                      (or (and corfu-separator-char
+                      (or (and corfu-separator-char ; command enables separator insertion
 			       (or (eq this-command 'corfu-insert-separator-char)
-				   (seq-contains-p (car corfu--input) corfu-separator-char)))
+				   (seq-contains-p  ; with separator, any further chars allowed
+				    (car corfu--input) corfu-separator-char)))
 			  (funcall completion-in-region-mode--predicate))))
            (corfu--update)
            t)))

--- a/corfu.el
+++ b/corfu.el
@@ -87,15 +87,15 @@ The value should lie between 0 and corfu-count/2."
                "see the new `corfu-separator-char' customization."
                "0.19")
 
-(defcustom corfu-separator-char ? 
+(defcustom corfu-separator-char ?\s 
   "Component separator character.
 The character used for separating components in the input.
 Useful for multi-component completion styles such as orderless.
 To use, bind `corfu-insert-separator-char' to a convenient
 key (e.g. M-SPC) in corfu-map, and use this binding to enter the
 first separator character.  Both this command and the presence of
-this separator character within the input will inhibit quitting
-on completion boundaries."
+the separator character within the input will inhibit quitting on
+completion boundaries."
     :type 'character)
 
 (defcustom corfu-quit-no-match 1.0

--- a/corfu.el
+++ b/corfu.el
@@ -83,11 +83,20 @@ The value should lie between 0 and corfu-count/2."
   "Preselect first candidate."
   :type 'boolean)
 
-(defcustom corfu-quit-at-boundary nil
-  "Automatically quit at completion field/word boundary.
-If automatic quitting is disabled, Orderless filter strings with spaces
-are allowed."
-  :type 'boolean)
+(make-obsolete 'corfu-quit-at-boundary
+               "see the new `corfu-separator-char' customization."
+               "0.19")
+
+(defcustom corfu-separator-char ? 
+  "Component separator character.
+The character used for separating components in the input.
+Useful for multi-component completion styles such as orderless.
+To use, bind `corfu-insert-separator-char' to a convenient
+key (e.g. M-SPC) in corfu-map, and use this binding to enter the
+first separator character.  Both this command and the presence of
+this separator character within the input will inhibit quitting
+on completion boundaries."
+    :type 'character)
 
 (defcustom corfu-quit-no-match 1.0
   "Automatically quit if no matching candidate is found.
@@ -842,6 +851,13 @@ there hasn't been any input, then quit."
   "Return t if a candidate is selected and previewed."
   (and corfu-preview-current (/= corfu--index corfu--preselect)))
 
+
+(defun corfu-insert-separator-char ()
+  "Insert a separator character and inhibit quit on completion boundary.
+Bind to a convenient key in corfu-map."
+  (interactive)
+  (insert corfu-separator-char))
+
 (defun corfu--post-command ()
   "Refresh Corfu after last command."
   (or (pcase completion-in-region--data
@@ -855,8 +871,9 @@ there hasn't been any input, then quit."
                       (save-excursion
                         (goto-char beg)
                         (<= (line-beginning-position) pt (line-end-position)))
-                      (or (not corfu-quit-at-boundary)
-                          (funcall completion-in-region-mode--predicate))))
+                      (or (eq this-command 'corfu-insert-separator-char)
+			  (seq-contains-p (car corfu--input) corfu-separator-char)
+			  (funcall completion-in-region-mode--predicate))))
            (corfu--update)
            t)))
       (corfu-quit)))

--- a/corfu.el
+++ b/corfu.el
@@ -875,8 +875,8 @@ there hasn't been any input, then quit."
                         (<= (line-beginning-position) pt (line-end-position)))
                       (or (and corfu-separator ;; command enables separator insertion
 			       (or (eq this-command #'corfu-insert-separator)
-				   (seq-contains-p  ;; with separator, any further chars allowed
-				    (car corfu--input) corfu-separator)))
+                                   ;; with separator, any further chars allowed
+				   (seq-contains-p (car corfu--input) corfu-separator)))
 			  (funcall completion-in-region-mode--predicate))))
            (corfu--update)
            t)))

--- a/corfu.el
+++ b/corfu.el
@@ -567,7 +567,8 @@ A scroll bar is displayed from LO to LO+BAR."
 
 (defun corfu--move-prefix-candidates-to-front (field candidates)
   "Move CANDIDATES which match prefix of FIELD to the beginning."
-  (let* ((word (replace-regexp-in-string " .*" "" field))
+  (let* ((word (replace-regexp-in-string
+		(format "[%c].*" corfu-separator-char) "" field))
          (len (length word)))
     (corfu--partition!
      candidates

--- a/corfu.el
+++ b/corfu.el
@@ -568,8 +568,8 @@ A scroll bar is displayed from LO to LO+BAR."
 
 (defun corfu--move-prefix-candidates-to-front (field candidates)
   "Move CANDIDATES which match prefix of FIELD to the beginning."
-  (let* ((pos (seq-position field corfu-separator-char))
-	 (word (if pos (substring field 0 pos) field))
+  (let* ((word (substring field 0
+                          (seq-position field corfu-separator-char)))
          (len (length word)))
     (corfu--partition!
      candidates

--- a/corfu.el
+++ b/corfu.el
@@ -568,8 +568,8 @@ A scroll bar is displayed from LO to LO+BAR."
 
 (defun corfu--move-prefix-candidates-to-front (field candidates)
   "Move CANDIDATES which match prefix of FIELD to the beginning."
-  (let* ((word (substring field 0
-                          (seq-position field corfu-separator-char)))
+  (let* ((pos (seq-position field corfu-separator-char))
+	 (word (if pos (substring field 0 pos) field))
          (len (length word)))
     (corfu--partition!
      candidates

--- a/corfu.el
+++ b/corfu.el
@@ -87,7 +87,7 @@ The value should lie between 0 and corfu-count/2."
                "see the new `corfu-separator-char' customization."
                "0.19")
 
-(defcustom corfu-separator-char ?\s 
+(defcustom corfu-separator-char ?\s
   "Component separator character.
 The character used for separating components in the input.  If
 non-nil, the presence of this separator character will inhibit

--- a/corfu.el
+++ b/corfu.el
@@ -568,7 +568,7 @@ A scroll bar is displayed from LO to LO+BAR."
 (defun corfu--move-prefix-candidates-to-front (field candidates)
   "Move CANDIDATES which match prefix of FIELD to the beginning."
   (let* ((word (replace-regexp-in-string
-		(format "[%c].*" corfu-separator-char) "" field))
+                (format "[%c].*" corfu-separator-char) "" field))
          (len (length word)))
     (corfu--partition!
      candidates
@@ -873,8 +873,8 @@ Bind to a convenient key in corfu-map."
                         (goto-char beg)
                         (<= (line-beginning-position) pt (line-end-position)))
                       (or (eq this-command 'corfu-insert-separator-char)
-			  (seq-contains-p (car corfu--input) corfu-separator-char)
-			  (funcall completion-in-region-mode--predicate))))
+                          (seq-contains-p (car corfu--input) corfu-separator-char)
+                          (funcall completion-in-region-mode--predicate))))
            (corfu--update)
            t)))
       (corfu-quit)))


### PR DESCRIPTION
Implement a component separator character and associated insertion command (`corfu-insert-separator-char`), used to inhibit quitting at completion boundaries (see #119).  This character is also removed from prefix sorting, superseding #118.

This is useful for multi-component completion styles such as orderless.  A convenient key binding for `corfu-insert-separator-char` such as `M-SPC` can be used to insert the initial completion component separator.

Obsoletes `corfu-quit-at-boundary` (for v0.19).  Setup documentation is provided.