### PR TITLE
Fix doc for restoring default behavior

### DIFF
--- a/README.org
+++ b/README.org
@@ -241,9 +241,12 @@ Then, when a new orderless component is desired, simply use =M-SPC=
 input, and arbitrary orderless search terms and new separators can be entered
 thereafter.
 
-Note that ~corfu-separator~ replaced and obsoleted ~corfu-quit-at-boundary~. If you
-want to restore the old behavior of ~corfu-quit-at-boundary=t~ you can bind
-~corfu-insert-separator~ to =SPC= in ~corfu-map~.
+Note that ~corfu-separator~ replaced and obsoleted
+~corfu-quit-at-boundary~. If you want similar behavior as with
+~corfu-quit-at-boundary=nil~, you can bind ~corfu-insert-separator~ to
+=SPC= (or whatever separator character you use) in ~corfu-map~.  If
+you /always/ want to quit at the boundary, simply set ~corfu-separator~ to
+~nil~.
 
  #+begin_src emacs-lisp
    (use-package corfu


### PR DESCRIPTION
The default behavior was quit-at-boundary=nil, and that's achieved by always "blocking" the boundary check, by binding your separator character to the new insert command.  This is only approximate, because other boundary-breakers like punctuation will still cause a quit in the 1st component.  But you won't need M-SPC to avoid quits (and will have lots of "false-positives").  The analogous setting for quit-at-boundary=t (_always_ quit at boundary) is corfu-separator=nil.