### PR TITLE
Delay docsig function call with timer

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -131,7 +131,7 @@ separator: Only stay alive if there is no match and
   "Width of the bar in units of the character width."
   :type 'float)
 
-(defcustom corfu-echo-documentation 0.2
+(defcustom corfu-echo-documentation '(1.0 0.2)
   "Show documentation string in the echo area after that number of seconds.
 Set to nil to disable docsig, or t to echo immediately on
 selecting a new candidate.  Can also be a 2-element list of


### PR DESCRIPTION
This implements a timer for calling the company-docsig function and displaying its results.  The impetus is to work more smoothly with costly docsig function which interact with servers or processes.    This uses only a single short delay, which I find works well, allowing you to scroll through many candidates without querying for docsig, then pausing briefly on any candidate to query and echo its short documentation.  Fixes #131.