### PR TITLE
.gitignore: Ignore corfu.texi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/corfu.texi


### PR DESCRIPTION
This file is automatically generated from README.org and must not be
commited.