### PR TITLE
Fix corfu get wrong size for frame in HiDPI screen, use fit-frame-to-buffer-1 adjust frame automatically.

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -449,7 +449,7 @@ The completion backend can override this with
       (set-window-buffer win buffer)
       ;; Mark window as dedicated to prevent frame reuse (#60)
       (set-window-dedicated-p win t))
-    (set-frame-size corfu--frame width height t)
+    (fit-frame-to-buffer-1 corfu--frame nil nil nil nil nil)
     (if (frame-visible-p corfu--frame)
         ;; XXX HACK Avoid flicker when frame is already visible.
         ;; Redisplay, wait for resize and then move the frame.


### PR DESCRIPTION
Hi

I'm author of [lsp-bridge](https://github.com/manateelazycat/lsp-bridge), lsp-bridge's global is become fastest LSP client for Emacs.

I found corfu get wrong size for frame when corfu running in HiDPI screen.

Below is screenshot before patch:
![2022-05-10 17-45-39 的屏幕截图](https://user-images.githubusercontent.com/237487/167601406-9ebe6951-66f9-4238-9e31-b279b0c962f3.png)

Below is screenshot after patch:
![2022-05-10 17-45-52 的屏幕截图](https://user-images.githubusercontent.com/237487/167601474-38d653de-a15b-4c66-b017-c65580408247.png)

We should use fit-frame-to-buffer-1 adjust frame automatically.

