### PR TITLE
Preview first candidate

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -894,7 +894,8 @@ there hasn't been any input, then quit."
         (corfu--done str 'finished)))
      ;; 3) There exist candidates => Show candidates popup.
      (corfu--candidates
-      (corfu--preview-current beg end)
+      (when (or (not (cdr corfu--candidates)) (/= corfu--index corfu--preselect))
+        (corfu--preview-current beg end))
       (corfu--echo-documentation)
       ;; TODO unobtrusive mode
       ;; (when (or (not corfu-preview-current)
@@ -902,7 +903,10 @@ there hasn't been any input, then quit."
       ;;           (< corfu--index 0)
       ;;           (/= corfu--index corfu--preselect))
       ;;   (corfu--candidates-popup beg))
-      (corfu--candidates-popup beg)
+      (if (cdr corfu--candidates)
+          (corfu--candidates-popup beg)
+        (corfu--popup-hide))
+
       )
      ;; 4) There are no candidates & corfu-quit-no-match => Confirmation popup.
      ((and (not corfu--candidates)


### PR DESCRIPTION
This implements preview of the first candidate, similar to the proposals in #211, #215 and #222. We could even hide the popup in more cases, e.g., when there is only a single candidate. Maybe it also makes sense to hide the popup always as long as it hasn't been requested explicitly. See also the reddit discussion in https://old.reddit.com/r/emacs/comments/xi9jdx/autocomplete_previews_while_typing_w_plugable/ started by @ideasman42. But I am not sure if we can replicate the behavior described there satisfactorily given the existing Corfu interaction model.