### PR TITLE
Simplify the definition of the minor-mode

### DIFF
--- a/extensions/corfu-indexed.el
+++ b/extensions/corfu-indexed.el
@@ -94,15 +94,14 @@
 (define-minor-mode corfu-indexed-mode
   "Prefix candidates with indices."
   :global t :group 'corfu
-  (cond
-   (corfu-indexed-mode
-    (advice-add #'corfu--affixate :filter-return #'corfu-indexed--affixate)
-    (dolist (cmd corfu-indexed--commands)
-      (advice-add cmd :around #'corfu-indexed--handle-prefix)))
-   (t
+  (if corfu-indexed-mode
+      (progn
+        (advice-add #'corfu--affixate :filter-return #'corfu-indexed--affixate)
+        (dolist (cmd corfu-indexed--commands)
+          (advice-add cmd :around #'corfu-indexed--handle-prefix)))
     (advice-remove #'corfu--affixate #'corfu-indexed--affixate)
     (dolist (cmd corfu-indexed--commands)
-      (advice-remove cmd #'corfu-indexed--handle-prefix)))))
+      (advice-remove cmd #'corfu-indexed--handle-prefix))))
 
 (provide 'corfu-indexed)
 ;;; corfu-indexed.el ends here


### PR DESCRIPTION
* extensions/corfu-indexed.el (corfu-indexed-mode): Use (if ...) instead of (cond ...) with two clauses for minor-mode definition.