### PR TITLE
Limit printing depth/length to reduce doc lag

### DIFF
--- a/extensions/corfu-docframe.el
+++ b/extensions/corfu-docframe.el
@@ -69,6 +69,16 @@
   :group 'corfu
   :type 'integer)
 
+(defcustom corfu-docframe-print-level 3
+  "Value for `print-level' while printing value in doc."
+  :group 'corfu
+  :type 'integer)
+
+(defcustom corfu-docframe-print-length 12
+  "Value for `print-length' while printing value in doc."
+  :group 'corfu
+  :type 'integer)
+
 (defcustom corfu-docframe-resize t
   "Resize the corfu doc popup automatically if non-nil."
   :group 'corfu
@@ -116,7 +126,9 @@ Returns nil if an error occurs or the documentation content is empty."
   (when-let* ((fun (plist-get corfu--extra :company-doc-buffer))
               (res (save-excursion
                      (let ((inhibit-message t)
-                           (message-log-max nil))
+                           (message-log-max nil)
+                           (print-level corfu-docframe-print-level)
+                           (print-length corfu-docframe-print-length))
                        (funcall fun candidate)))))
     (with-current-buffer (or (car-safe res) res)
       (setq res (buffer-string)))


### PR DESCRIPTION
There is a lag when displaying doc of a variable which has a value of large list.

Steps to reproduce:

1. Start Emacs:

```sh
$ emacs -Q --eval "\
  (progn
    (toggle-debug-on-error)
    (require 'seq)
    (setq user-emacs-directory
          (car (seq-filter
                #'file-exists-p
                (list (format \"~/.emacs.d/%s/\" emacs-version)
                      (format \"~/.emacs.d/%s.%s/\" emacs-major-version emacs-minor-version)
                      \"~/.emacs.d/\"))))

    (setq package-user-dir (concat user-emacs-directory \"elpa/\"))
    (package-initialize)
    ;; Add addtional local package here:
    (add-to-list 'load-path \"~/repos/emacs-corfu\")
    (add-to-list 'load-path \"~/repos/emacs-corfu/extensions\")
    ;; ---------------------------------------------------------------------------
    (require 'corfu)
    (require 'corfu-docframe)
    (setq corfu-auto t)
    (setq corfu-quit-at-boundary t)
    (setq corfu-preview-current nil)
    (setq corfu-docframe-auto t)
    (setq corfu-docframe-delay 0)
    (global-corfu-mode 1)
    (corfu-docframe-mode 1))"
```

1. Type `load-`.
1. Active completion, and the first two candidates should be `load-path` and `load-history`.
1. Press `C-n`.
1. Press `C-n`.
