### PR TITLE
corfu-popupinfo: Make sure the popup has a minimum height of 1 line

### DIFF
--- a/extensions/corfu-popupinfo.el
+++ b/extensions/corfu-popupinfo.el
@@ -219,9 +219,10 @@ all values are in pixels relative to the origin. See
 (defun corfu-popupinfo--size ()
   "Return popup size as pair."
   (let* ((cw (default-font-width))
+         (lh (default-line-height))
          (margin (* cw (+ (alist-get 'left-margin-width corfu-popupinfo--buffer-parameters)
                           (alist-get 'right-margin-width corfu-popupinfo--buffer-parameters))))
-         (max-height (* (default-line-height) corfu-popupinfo-max-height))
+         (max-height (* lh corfu-popupinfo-max-height))
          (max-width (* cw corfu-popupinfo-max-width)))
     (or (when corfu-popupinfo-resize
           (with-current-buffer " *corfu-popupinfo*"
@@ -233,7 +234,8 @@ all values are in pixels relative to the origin. See
               ;; Check that width is not exceeded. Otherwise use full height,
               ;; since lines will get wrapped.
               (when (<= (car size) max-width)
-                (cons (+ margin (car size)) (min (cdr size) max-height))))))
+                (cons (+ margin (car size))
+                      (min (max (cdr size) lh) max-height))))))
         (cons (+ margin max-width) max-height))))
 
 (defun corfu-popupinfo--frame-geometry (frame)


### PR DESCRIPTION
The attribute `:height` of `corfu-popupinfo` face is set to 0.8 by default, the calculated minimum height (1 line height) of the popup will be smaller than the actual minimum height of the popup (default 1 line height), resulting in a deviation in the position setting when the popup is in the top direction.