### PR TITLE
Limit the vertical area for left/right popupinfo frame to parent frame's

### DIFF
--- a/extensions/corfu-popupinfo.el
+++ b/extensions/corfu-popupinfo.el
@@ -391,7 +391,8 @@ visible, the other window is moved to beginning or end."
   (if (corfu-popupinfo--visible-p)
       (with-selected-frame corfu-popupinfo--frame
         (with-current-buffer " *corfu-popupinfo*"
-          (with-no-warnings (end-of-buffer n))))
+          (with-no-warnings
+	    (end-of-buffer n))))
     (end-of-buffer-other-window n)))
 
 (defun corfu-popupinfo-beginning (&optional n)

--- a/extensions/corfu-popupinfo.el
+++ b/extensions/corfu-popupinfo.el
@@ -388,7 +388,7 @@ visible, the other window is moved to beginning or end."
   (if (corfu-popupinfo--visible-p)
       (with-selected-frame corfu-popupinfo--frame
         (with-current-buffer " *corfu-popupinfo*"
-          (end-of-buffer n)))
+          (with-no-warnings (end-of-buffer n))))
     (end-of-buffer-other-window n)))
 
 (defun corfu-popupinfo-beginning-of-buffer (&optional n)

--- a/extensions/corfu-popupinfo.el
+++ b/extensions/corfu-popupinfo.el
@@ -119,8 +119,8 @@ popup can be requested manually via `corfu-popupinfo-toggle',
     (define-key map "\M-t" #'corfu-popupinfo-toggle)
     (define-key map [remap scroll-other-window] #'corfu-popupinfo-scroll-up)
     (define-key map [remap scroll-other-window-down] #'corfu-popupinfo-scroll-down)
-    (define-key map [remap end-of-buffer-other-window] #'corfu-popupinfo-end-of-buffer)
-    (define-key map [remap beginning-of-buffer-other-window] #'corfu-popupinfo-beginning-of-buffer)
+    (define-key map [remap end-of-buffer-other-window] #'corfu-popupinfo-end)
+    (define-key map [remap beginning-of-buffer-other-window] #'corfu-popupinfo-beginning)
     map)
   "Additional keymap activated in popupinfo mode.")
 
@@ -381,7 +381,7 @@ form (X Y WIDTH HEIGHT DIR)."
   "Clear the info popup buffer content and hide it."
   (corfu--hide-frame corfu-popupinfo--frame))
 
-(defun corfu-popupinfo-end-of-buffer (&optional n)
+(defun corfu-popupinfo-end (&optional n)
   "Scroll text of info popup window to its end.
 
 If arg N is omitted or nil, scroll to end.  If a numerical value,
@@ -394,12 +394,12 @@ visible, the other window is moved to beginning or end."
           (with-no-warnings (end-of-buffer n))))
     (end-of-buffer-other-window n)))
 
-(defun corfu-popupinfo-beginning-of-buffer (&optional n)
+(defun corfu-popupinfo-beginning (&optional n)
   "Scroll text of info popup window to beginning of buffer.
 
-See `corfu-popupinfo-end-of-buffer' for more details."
+See `corfu-popupinfo-end' for the argument N."
   (interactive "P")
-  (corfu-popupinfo-end-of-buffer (- 10 (if (numberp n) n 0))))
+  (corfu-popupinfo-end (- 10 (if (numberp n) n 0))))
 
 (defun corfu-popupinfo-scroll-up (&optional n)
   "Scroll text of info popup window upward N lines.

--- a/extensions/corfu-popupinfo.el
+++ b/extensions/corfu-popupinfo.el
@@ -287,11 +287,12 @@ form (X Y WIDTH HEIGHT DIR)."
                (`(,cfx ,cfy ,cfw ,cfh) (corfu-popupinfo--frame-geometry corfu--frame))
                ;; Left display area
                (al (list (max 0 (- cfx (car ps) border)) cfy
-                         (min (- cfx border) (car ps)) (cdr ps) 'left))
+                         (min (- cfx border) (car ps))
+			 (min (cdr ps) (- pfh cfy)) 'left))
                ;; Right display area
                (arx (+ cfx cfw (- border)))
                (ar (list arx cfy (min (- pfw arx border border) (car ps))
-                         (cdr ps) 'right))
+                         (min (cdr ps) (- pfh cfy)) 'right))
                ;; Vertical display area
                (avw (min (car ps) (- pfw cfx border border)))
                (av (if (>= cfy (+ lh (cadr (window-inside-pixel-edges))

--- a/extensions/corfu-popupinfo.el
+++ b/extensions/corfu-popupinfo.el
@@ -119,6 +119,8 @@ popup can be requested manually via `corfu-popupinfo-toggle',
     (define-key map "\M-t" #'corfu-popupinfo-toggle)
     (define-key map [remap scroll-other-window] #'corfu-popupinfo-scroll-up)
     (define-key map [remap scroll-other-window-down] #'corfu-popupinfo-scroll-down)
+    (define-key map [remap end-of-buffer-other-window] #'corfu-popupinfo-end-of-buffer)
+    (define-key map [remap beginning-of-buffer-other-window] #'corfu-popupinfo-beginning-of-buffer)
     map)
   "Additional keymap activated in popupinfo mode.")
 
@@ -376,11 +378,31 @@ form (X Y WIDTH HEIGHT DIR)."
   "Clear the info popup buffer content and hide it."
   (corfu--hide-frame corfu-popupinfo--frame))
 
+(defun corfu-popupinfo-end-of-buffer (&optional n)
+  "Scroll text of info popup window to its end.
+
+If arg N is omitted or nil, scroll to end.  If a numerical value,
+put point N/10 of the way from the end.  If the info popup is not
+visible, the other window is moved to beginning or end."
+  (interactive "P")
+  (if (corfu-popupinfo--visible-p)
+      (with-selected-frame corfu-popupinfo--frame
+        (with-current-buffer " *corfu-popupinfo*"
+          (end-of-buffer n)))
+    (end-of-buffer-other-window n)))
+
+(defun corfu-popupinfo-beginning-of-buffer (&optional n)
+  "Scroll text of info popup window to beginning of buffer.
+
+See `corfu-popupinfo-end-of-buffer' for more details."
+  (interactive "P")
+  (corfu-popupinfo-end-of-buffer (- 10 (if (numberp n) n 0))))
+
 (defun corfu-popupinfo-scroll-up (&optional n)
   "Scroll text of info popup window upward N lines.
 
 If ARG is omitted or nil, scroll upward by a near full screen.
-See `scroll-up' for details. If the info popup is not visible,
+See `scroll-up' for details.  If the info popup is not visible,
 the other window is scrolled."
   (interactive "p")
   (if (corfu-popupinfo--visible-p)


### PR DESCRIPTION
This simple change alters the computed area available for `left` and `right` `popupinfo` frames, limiting the height to the remaining vertical extent of the parent frame.  In practice, this can mean `vertical` placement can be used on an emergency basis when `corfu-popupinfo-min-height` is large, even if it is not configured in `corfu-popupinfo-direction`.  Fixes #271.