### PR TITLE
Align popups at the bottom when the doc popup is taller than the candidates popup and limit height of the doc popup to avoid exceeding the parent frame

### DIFF
--- a/extensions/corfu-popupinfo.el
+++ b/extensions/corfu-popupinfo.el
@@ -294,7 +294,7 @@ form (X Y WIDTH HEIGHT DIR)."
                ;; Left display area
                (ahy (if (or below (< (cdr ps) cfh))
                         cfy
-                      (- (+ cfy cfh) (cdr ps) border border)))
+                      (max 0 (- (+ cfy cfh) (cdr ps) border border))))
                (al (list (max 0 (- cfx (car ps) border)) ahy
                          (min (- cfx border) (car ps)) (cdr ps) 'left))
                ;; Right display area

--- a/extensions/corfu-popupinfo.el
+++ b/extensions/corfu-popupinfo.el
@@ -292,7 +292,9 @@ form (X Y WIDTH HEIGHT DIR)."
                                  (window-tab-line-height)
                                  (or (cdr (posn-x-y (posn-at-point (point)))) 0))))
                ;; Left display area
-               (ahy (if below cfy (- (+ cfy cfh) (cdr ps) border border)))
+               (ahy (if (or below (< (cdr ps) cfh))
+                        cfy
+                      (- (+ cfy cfh) (cdr ps) border border)))
                (al (list (max 0 (- cfx (car ps) border)) ahy
                          (min (- cfx border) (car ps)) (cdr ps) 'left))
                ;; Right display area

--- a/extensions/corfu-popupinfo.el
+++ b/extensions/corfu-popupinfo.el
@@ -292,15 +292,16 @@ form (X Y WIDTH HEIGHT DIR)."
                                  (window-tab-line-height)
                                  (or (cdr (posn-x-y (posn-at-point (point)))) 0))))
                ;; Left display area
-               (ahy (if (or below (< (cdr ps) cfh))
-                        cfy
-                      (max 0 (- (+ cfy cfh) (cdr ps) border border))))
+               (`(,ahy ,ahh)
+                 (if (or below (< (cdr ps) cfh))
+                     (list cfy (min (- pfh cfy) (cdr ps)))
+                   (list (max 0 (- (+ cfy cfh) (cdr ps) border border))
+                         (min (- (+ cfy cfh) border border) (cdr ps)))))
                (al (list (max 0 (- cfx (car ps) border)) ahy
-                         (min (- cfx border) (car ps)) (cdr ps) 'left))
+                         (min (- cfx border) (car ps)) ahh 'left))
                ;; Right display area
                (arx (+ cfx cfw (- border)))
-               (ar (list arx ahy (min (- pfw arx border border) (car ps))
-                         (cdr ps) 'right))
+               (ar (list arx ahy (min (- pfw arx border border) (car ps)) ahh 'right))
                ;; Vertical display area
                (avw (min (car ps) (- pfw cfx border border)))
                (av (if below

--- a/extensions/corfu-popupinfo.el
+++ b/extensions/corfu-popupinfo.el
@@ -291,12 +291,15 @@ form (X Y WIDTH HEIGHT DIR)."
                (below (>= cfy (+ lh (cadr (window-inside-pixel-edges))
                                  (window-tab-line-height)
                                  (or (cdr (posn-x-y (posn-at-point (point)))) 0))))
+               ;; Popups aligned at top
+               (top-aligned (or below (< (cdr ps) cfh)))
                ;; Left display area
-               (`(,ahy ,ahh)
-                 (if (or below (< (cdr ps) cfh))
-                     (list cfy (min (- pfh cfy) (cdr ps)))
-                   (list (max 0 (- (+ cfy cfh) (cdr ps) border border))
-                         (min (- (+ cfy cfh) border border) (cdr ps)))))
+               (ahy (if top-aligned
+                        cfy
+                      (max 0 (- (+ cfy cfh) border border (cdr ps)))))
+               (ahh (if top-aligned
+                        (min (- pfh cfy) (cdr ps))
+                      (min (- (+ cfy cfh) border border) (cdr ps))))
                (al (list (max 0 (- cfx (car ps) border)) ahy
                          (min (- cfx border) (car ps)) ahh 'left))
                ;; Right display area


### PR DESCRIPTION
See the discussion [here](https://github.com/minad/corfu/issues/271#issuecomment-1337102561).