### PR TITLE
Add support for asynchronous Capfs

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -1139,19 +1139,12 @@ ASYNC may be an asynchronous capf result."
                   (lambda ()
                     ;; Ask the backend for refreshing
                     (funcall fun (lambda (ret)
+                                   ;; TODO ensure that this runs in the correct buffer.
                                    (pcase ret
                                      (`(,beg ,end ,table . ,plist)
-                                      ;; TODO ensure that this runs in the correct buffer.
-                                      ;; TODO check validity of boundaries
-                                      ;; If valid, update completion data and UI.
-                                      (setq completion-in-region--data
-                                            (list (if (markerp beg) beg (copy-marker beg))
-                                                  (copy-marker end t)
-                                                  table
-                                                  (plist-get plist :predicate))
-                                            corfu--extra plist)
+                                      ;; TODO Check validity of boundaries.
+                                      ;; If valid, update UI. Otherwise quit.
                                       (corfu--post-command))
-                                     ;; TODO ensure correct buffer
                                      (_ (corfu-quit)))))
                     ;; Return t, since the predicate is invoked asynchronously
                     t)

--- a/corfu.el
+++ b/corfu.el
@@ -1136,7 +1136,9 @@ RESULT may be a capf result, if already present."
       (`(,fun ,beg ,end ,table . ,plist)
        (let ((completion-in-region-mode-predicate
               (or (plist-get plist :continue-predicate)
-                  (if result fun (lambda () (eq beg (car-safe (funcall fun)))))))
+                  (if fun
+                      (lambda () (eq beg (car-safe (funcall fun))))
+                    (lambda () t))))
              (completion-extra-properties plist))
          (setq completion-in-region--data
                (list (if (markerp beg) beg (copy-marker beg))
@@ -1161,7 +1163,7 @@ RESULT may be a capf result, if already present."
             (run-hook-wrapped 'completion-at-point-functions
                               #'corfu--auto-capf-wrapper-async
                               (lambda (result)
-                                (corfu--auto-deferred tick (or result t)))))
+                                (corfu--auto-deferred tick (cons nil result)))))
       (unless corfu--auto-cancel
         (if (<= corfu-auto-delay 0)
             (corfu--auto-deferred tick)

--- a/corfu.el
+++ b/corfu.el
@@ -1161,7 +1161,7 @@ RESULT may be a capf result, if already present."
     (let ((tick (corfu--auto-tick)))
       (setq corfu--auto-cancel
             (run-hook-wrapped 'completion-at-point-functions
-                              #'corfu--auto-capf-wrapper-async
+                              #'corfu--async-capf-wrapper
                               (lambda (result)
                                 (corfu--auto-deferred tick (cons nil result)))))
       (unless corfu--auto-cancel
@@ -1195,7 +1195,7 @@ Auto completion is only performed if the tick did not change."
     (remove-hook 'post-command-hook #'corfu--auto-post-command 'local)
     (kill-local-variable 'completion-in-region-function))))
 
-(defun corfu--auto-capf-wrapper-async (fun cb)
+(defun corfu--async-capf-wrapper (fun cb)
   "Call asynchronous capf FUN with CB."
   (and (symbolp fun) (get fun 'async-completion-at-point-function) (funcall fun cb)))
 

--- a/corfu.el
+++ b/corfu.el
@@ -1192,10 +1192,9 @@ Auto completion is only performed if the tick did not change."
     (remove-hook 'post-command-hook #'corfu--auto-post-command 'local)
     (kill-local-variable 'completion-in-region-function))))
 
-(defun corfu--auto-capf-wrapper-async (fun callback)
-  "Call asynchronous capf FUN with CALLBACK."
-  (when (and (symbolp fun) (get fun 'async-completion-at-point-function))
-    (funcall fun callback)))
+(defun corfu--auto-capf-wrapper-async (fun cb)
+  "Call asynchronous capf FUN with CB."
+  (and (symbolp fun) (get fun 'async-completion-at-point-function) (funcall fun cb)))
 
 (defun corfu--capf-wrapper (fun &optional prefix)
   "Wrapper for `completion-at-point' FUN.

--- a/corfu.el
+++ b/corfu.el
@@ -1137,6 +1137,7 @@ ASYNC may be an asynchronous capf result."
        (let ((completion-in-region-mode-predicate
               (if async
                   (lambda ()
+                    ;; TODO Implement cancellation.
                     ;; Ask the backend for refreshing
                     (funcall fun (lambda (ret)
                                    ;; TODO ensure that this runs in the correct buffer.

--- a/corfu.el
+++ b/corfu.el
@@ -1194,7 +1194,7 @@ Auto completion is only performed if the tick did not change."
 
 (defun corfu--auto-capf-wrapper-async (fun callback)
   "Call asynchronous capf FUN with CALLBACK."
-  (when (and (symbolp fun) (get fun 'corfu-async))
+  (when (and (symbolp fun) (get fun 'async-completion-at-point-function))
     (funcall fun callback)))
 
 (defun corfu--capf-wrapper (fun &optional prefix)

--- a/corfu.el
+++ b/corfu.el
@@ -1135,7 +1135,7 @@ RESULT may be a capf result, if already present."
                                           #'corfu--capf-wrapper)))
       (`(,fun ,beg ,end ,table . ,plist)
        (let ((completion-in-region-mode-predicate
-              (lambda () (eq beg (car-safe (funcall fun)))))
+              (if result fun (lambda () (eq beg (car-safe (funcall fun))))))
              (completion-extra-properties plist))
          (setq completion-in-region--data
                (list (if (markerp beg) beg (copy-marker beg))

--- a/corfu.el
+++ b/corfu.el
@@ -1140,15 +1140,15 @@ ASYNC may be an asynchronous capf result."
                     ;; Ask the backend for refreshing
                     (funcall fun (lambda (ret)
                                    ;; TODO ensure that this runs in the correct buffer.
-                                   (pcase ret
-                                     (`(,beg ,end ,table . ,plist)
-                                      ;; TODO Check validity of boundaries.
-                                      ;; If valid, update UI. Otherwise quit.
-                                      (corfu--post-command))
-                                     (_ (corfu-quit)))))
-                    ;; Return t, since the predicate is invoked asynchronously
+                                   (if-let* ((newbeg (car-safe ret))
+                                             ((= newbeg beg)))
+                                       (corfu--post-command)
+                                     (corfu-quit))))
+                    ;; Return t, since the predicate is invoked asynchronously.
                     t)
-                (lambda () (eq beg (car-safe (funcall fun))))))
+                (lambda ()
+                  (when-let (newbeg (car-safe (funcall fun)))
+                    (= newbeg beg)))))
              (completion-extra-properties plist))
          (setq completion-in-region--data
                (list (if (markerp beg) beg (copy-marker beg))

--- a/corfu.el
+++ b/corfu.el
@@ -1135,7 +1135,8 @@ RESULT may be a capf result, if already present."
                                           #'corfu--capf-wrapper)))
       (`(,fun ,beg ,end ,table . ,plist)
        (let ((completion-in-region-mode-predicate
-              (if result fun (lambda () (eq beg (car-safe (funcall fun))))))
+              (or (plist-get plist :continue-predicate)
+                  (if result fun (lambda () (eq beg (car-safe (funcall fun)))))))
              (completion-extra-properties plist))
          (setq completion-in-region--data
                (list (if (markerp beg) beg (copy-marker beg))


### PR DESCRIPTION
@jdtsmith I quickly wrote a small prototype. It is completely untested. 

There is a small difference in comparison to your proposal. Instead of `:before-complete` I use a symbol property `async-completion-at-point-function` since we have to determine beforehand if a Capf is actually asynchronous such that we don't have to walk through the entire `completion-at-point-functions` list. The asynchronous Capf is then called with a callback and must return a cancellation function. 

The addition is simple enough (addition of ~10 lines), but cannot be implemented as an extension. This still leaves us with a chicken and egg problem. Will there a backend which will implement this any time soon?