### PR TITLE
README: Add reference to corfu-candidate-overlay package

### DIFF
--- a/README.org
+++ b/README.org
@@ -520,6 +520,10 @@ enhance your setup.
 - [[https://github.com/minad/vertico][Vertico]]: You may also want to look into my Vertico package. Vertico is the
   minibuffer completion counterpart of Corfu.
 
+- [[https://code.bsdgeek.org/adam/corfu-candidate-overlay][corfu-candidate-overlay]]: Shows as-you-type auto-suggestion candidate overlay
+  with a visual indication of whether there are many or exactly one candidate
+  available (works only with corfu-auto popup disabled).
+
 * Alternatives
 
 - [[https://github.com/company-mode/company-mode][Company]]: Company is a widely used and mature completion package, which


### PR DESCRIPTION
Shameless plug, hope you don't mind.

Added a link and a short description to my corfu-candidate-overlay package that provides "as you type" overlay showing the first auto-suggestion candidate from Corfu. I do not use the auto popup and wanted to have some indication that I can auto-complete *something* and whether there are more than one suggestions present. Package requires corfu-auto to be disabled, so probably won't be of wide use but still could be of interest to someone ;-)

Sneak-peak of the overlay in action:
![image](https://github.com/minad/corfu/assets/147323/f010aff1-5956-40bd-94cb-e7e9528a254c)

Many thanks,
Adam.