### PR TITLE
Change the readme to match the online documentation for corfu-quit-at…

### DIFF
--- a/README.org
+++ b/README.org
@@ -349,7 +349,7 @@ thereafter.
 To treat the entire input as Orderless input, you can set the customization
 option ~corfu-quit-at-boundary~ to t. This disables the predicate which checks if
 the current completion boundary has been left. In contrast, if you always want
-to quit at the boundary, set ~corfu-quit-at-boundary~ to ~nil~. By default
+to quit at the boundary, set ~corfu-quit-at-boundary~ to ~t~. By default
 ~corfu-quit-at-boundary~ is set to ~separator~ which quits at completion boundaries
 as long as no separator has been inserted with ~corfu-insert-separator~.
 


### PR DESCRIPTION
The readme documentation seems to say that setting `corfu-quit-at-boundary` to `nil` makes corfu always quit at the boundary. The online docs say differently:
<img width="600" alt="Screenshot 2023-09-21 at 11 02 39 AM" src="https://github.com/minad/corfu/assets/190980/c8f12c1a-2da8-4524-ab60-da11a24955da">