### PR TITLE
Add corfu-popup-location defcustom (above or below current line)

### DIFF
--- a/README.org
+++ b/README.org
@@ -92,6 +92,7 @@ Here is an example configuration:
   ;; (corfu-preselect 'prompt)      ;; Preselect the prompt
   ;; (corfu-on-exact-match nil)     ;; Configure handling of exact matches
   ;; (corfu-scroll-margin 5)        ;; Use scroll margin
+  ;; (corfu-popup-location 'above)  ;; Default is below the point
 
   ;; Enable Corfu only for certain modes.
   ;; :hook ((prog-mode . corfu-mode)

--- a/corfu.el
+++ b/corfu.el
@@ -67,6 +67,13 @@ The value should lie between 0 and corfu-count/2."
   "Popup maximum width in characters."
   :type 'natnum)
 
+(defcustom corfu-popup-location 'below
+  "Location of the Corfu popup.
+The value can be either 'above or 'below.  The default value is 'below."
+  :type '(choice (const :tag "Above the point" above)
+                 (const :tag "Below the point" below))
+  :group 'corfu)
+
 (defcustom corfu-cycle nil
   "Enable cycling for `corfu-next' and `corfu-previous'."
   :type 'boolean)
@@ -972,9 +979,11 @@ A scroll bar is displayed from LO to LO+BAR."
              (x (max 0 (min (+ (car edge) (- (or (car pos) 0) ml (* cw off) border))
                             (- (frame-pixel-width) width))))
              (yb (+ (cadr edge) (window-tab-line-height) (or (cdr pos) 0) lh))
-             (y (if (> (+ yb (* corfu-count ch) lh lh) (frame-pixel-height))
+             (y (if (eq corfu-popup-location 'above)
                     (- yb height lh border border)
-                  yb))
+                  (if (> (+ yb (* corfu-count ch) lh lh) (frame-pixel-height))
+                      (- yb height lh border border)
+                    yb)))
              (row 0))
         (with-silent-modifications
           (erase-buffer)

--- a/corfu.el
+++ b/corfu.el
@@ -69,7 +69,9 @@ The value should lie between 0 and corfu-count/2."
 
 (defcustom corfu-popup-location 'below
   "Location of the Corfu popup.
-The value can be either 'above or 'below.  The default value is 'below."
+Sets the preferred location of the popup when there is space available:
+- above: Prefer to place the popup above the current line.
+- below: Prefer to place the popup below the current line (default)."
   :type '(choice (const :tag "Above the point" above)
                  (const :tag "Below the point" below))
   :group 'corfu)


### PR DESCRIPTION
When a completion backend proposes multi-line completions (e.g., codeium.el), the corfu popup (which appears below the point by default) covers the completion preview. This patch introduces a defcustom `corfu-popup-location` which allows the user to set a preference for the popup to appear above the current line if there is space available. This allows one to see both the completions and the preview in the case of a multi-line completion.