### PR TITLE
corfu: Reduce number of auto-timers created

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -983,9 +983,6 @@ See `completion-in-region' for the arguments BEG, END, TABLE, PRED."
 
 (defun corfu--auto-post-command ()
   "Post command hook which initiates auto completion."
-  (when corfu--auto-timer
-    (cancel-timer corfu--auto-timer)
-    (setq corfu--auto-timer nil))
   (when (and (not completion-in-region-mode)
              (not defining-kbd-macro)
              (not buffer-read-only)
@@ -995,9 +992,11 @@ See `completion-in-region' for the arguments BEG, END, TABLE, PRED."
         (corfu--auto-complete-deferred)
       ;; Do not use idle timer since this leads to unpredictable pauses, in
       ;; particular with `flyspell-mode'.
-      (setq corfu--auto-timer
-            (run-at-time corfu-auto-delay nil
-                         #'corfu--auto-complete-deferred (corfu--auto-tick))))))
+      (if corfu--auto-timer
+          (timer-set-time corfu--auto-timer corfu-auto-delay)
+        (setq corfu--auto-timer
+              (run-at-time corfu-auto-delay nil
+                           #'corfu--auto-complete-deferred (corfu--auto-tick)))))))
 
 (defun corfu--auto-tick ()
   "Return the current tick/status of the buffer.


### PR DESCRIPTION
If `corfu--auto-timer` is running, we can reset its time in the post command hook instead of cancelling the timer and creating a new one.

Here's a rough calculation: With 8 byte integers (calculated from `most-possible-fixnum`), the `corfu--auto-timer` object is a vector of approximately:

```
  48 bytes for various times
+ (size of function address)
+ (size of window address)
+ (size of current buffer address)
+ (8 bytes from buffer-modified-tick)
+ (8 bytes from point)
```

Let's say the function, window and current buffer addresses are word size, or 8 bytes each.  The timer object is then at least 88 bytes.

This timer is canceled and recreated each time in `post-command-hook` via `corfu--auto-post-command` when corfu isn't triggered, let's say 60 times/min when typing.  That's about 5 Kb of garbage/min we can avoid.  `corfu--auto-post-command` should also run slightly faster when corfu doesn't pop up, i.e. for most non-typing commands.

This might be a bit of a micro-optimization, but it doesn't appear to have any downside and the code is a little shorter too, so I thought I'd make a PR.
