### PR TITLE
Close completion popup if text len is less than corfu-auto-prefix

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -979,8 +979,9 @@ See `completion-in-region' for the arguments BEG, END, TABLE, PRED."
       (`(,fun ,beg ,end ,table . ,plist)
        (let ((completion-in-region-mode-predicate
               (lambda ()
-                (when-let ((newbeg (car-safe (funcall fun))))
-                  (= newbeg beg))))
+                (and (<= corfu-auto-prefix (- (point) beg))
+                    (when-let ((newbeg (car-safe (funcall fun))))
+                      (= newbeg beg)))))
              (completion-extra-properties plist))
          (corfu--setup beg end table (plist-get plist :predicate))
          (corfu--exhibit 'auto))))))


### PR DESCRIPTION
Currently the auto completion popup appears as soon as user enters `corfu-auto-prefix` number of characters but it never goes away even if user removes some characters. It may not sound like a problem but it freezes Emacs if there are too many options for completion. 

For example (when `corfu-auto-prefix` == `3`):
- Enter `(mes` (I want to enter `(message "...")` but then I changed my mind and want to enter something else)
- Completion popup appears
- Delete `s`
- Completion popup is still there even though the length of entered text is less than `corfu-auto-prefix`
- Delete `e` 
- Completion popup is still there and (at least in my case) Emacs is getting frozen for a few seconds because there are too many options available for letter `m` to auto complete. 

Expected behavior for me is to close the completion popup as soon as the number of entered characters are less than `corfu-auto-prefix`.

This issue is less prominent if you have a habit to use`M-Backspace` instead of `Backspace-Many-Times` as I used to do. 
I suffer from this issue every day but I can't find anyone complaining about it which makes me think that I either missed a variable that actually fixes this issue or I maybe have too many completion sources which makes my Emacs slow... 

In any case, let me know if you find this change valuable and let me know if I can improve anything code-wise. 


