### PR TITLE
Fix unbalanced parentheses in the README

### DIFF
--- a/README.org
+++ b/README.org
@@ -244,7 +244,7 @@ source code for further details.
 #+begin_src emacs-lisp
 (defun orderless-fast-dispatch (word index total)
   (and (= index 0) (= total 1) (length< word 4)
-       (cons 'orderless-literal-prefix word))))
+       (cons 'orderless-literal-prefix word)))
 
 (orderless-define-completion-style orderless-fast
   (orderless-style-dispatchers '(orderless-fast-dispatch))


### PR DESCRIPTION
Just found this out after trying to copy and paste the function.

I blame John McCarthy for having the idea to use so many parentheses in a language.