### PR TITLE
corfu-popupinfo: Always retrieve new content regardless of candidate change

### DIFF
--- a/extensions/corfu-popupinfo.el
+++ b/extensions/corfu-popupinfo.el
@@ -348,19 +348,21 @@ form (X Y WIDTH HEIGHT DIR)."
                       (equal candidate corfu-popupinfo--candidate))))
            (new-coords (frame-edges corfu--frame 'inner-edges))
            (coords-changed (not (equal new-coords corfu-popupinfo--coordinates))))
-      (when cand-changed
-        (if-let ((content (funcall corfu-popupinfo--function candidate)))
-            (with-current-buffer (corfu--make-buffer " *corfu-popupinfo*")
-              (with-silent-modifications
-                (erase-buffer)
-                (insert content)
-                (goto-char (point-min)))
-              (dolist (var corfu-popupinfo--buffer-parameters)
-                (set (make-local-variable (car var)) (cdr var)))
-              (when-let ((m (memq 'corfu-default (alist-get 'default face-remapping-alist))))
-                (setcar m 'corfu-popupinfo)))
-          (corfu-popupinfo--hide)
-          (setq cand-changed nil coords-changed nil)))
+      ;; Always retrieve new content regardless of candidate change
+      (if-let ((content (funcall corfu-popupinfo--function candidate)))
+          (with-current-buffer (corfu--make-buffer " *corfu-popupinfo*")
+            (with-silent-modifications
+              (erase-buffer)
+              (insert content)
+              (goto-char (point-min)))
+            (dolist (var corfu-popupinfo--buffer-parameters)
+              (set (make-local-variable (car var)) (cdr var)))
+            (when-let ((m (memq 'corfu-default (alist-get 'default face-remapping-alist))))
+              (setcar m 'corfu-popupinfo))
+            (setq cand-changed t))  ;; Ensure it marks candidate change as true
+        (corfu-popupinfo--hide)
+        (setq cand-changed nil coords-changed nil))
+      ;; Update the frame position regardless of candidate change
       (when (or cand-changed coords-changed)
         (pcase-let* ((border (alist-get 'internal-border-width corfu--frame-parameters))
                      (`(,area-x ,area-y ,area-w ,area-h ,area-d)


### PR DESCRIPTION
### Changes Introduction

This PR introduces modifications to the `corfu-popupinfo--show` function to ensure the content in the popup is always refreshed regardless of candidate changes and properly triggers candidate change updates.

### Summary of Changes

1. **Always Retrieve New Content**:
   - The original implementation only retrieved new content if the candidate had changed. The new implementation retrieves new content regardless of candidate changes, ensuring the popup always displays the most current information.

2. **Update `cand-changed` Flag**:
   - The updated code sets `cand-changed` to true when new content is successfully retrieved. This flag ensures that the subsequent frame updates are triggered.

---

### Detailed Explanation

#### Original 
**In the original implementation, the popup info does not update for different candidates with the same name.**

https://github.com/minad/corfu/assets/10104705/7477aa23-bef5-437c-a922-14eb36636f8a

#### Modified
**In the modified implementation, the popup info updates for different candidates with the same name.**

https://github.com/minad/corfu/assets/10104705/48d868d3-5aed-4847-954e-6b6573bbaa06

### Conclusion

These changes improve the robustness of the `corfu-popupinfo` functionality by ensuring that the displayed data is always current and the candidate change is properly flagged.