### PR TITLE
Calculate popup width for lines with uneven character widths correctly

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -776,7 +776,7 @@ terminal."
              do
              ;; `corfu-current' may affect frame-width too
              (when (= i curr)
-               (cl-loop for s in (list cand prefix suffix)
+               (cl-loop for s in (list cand prefix suffix marginl marginr)
                         do (add-face-text-property 0 (length s) 'corfu-current t s)))
 
              (cl-incf i)

--- a/corfu.el
+++ b/corfu.el
@@ -219,10 +219,8 @@ See also the settings `corfu-auto-delay', `corfu-auto-prefix' and
   "Face used to highlight the currently selected candidate.")
 
 (defface corfu-bar
-  '((((class color) (min-colors 88) (background dark))
-     :background "#a8a8a8" :foreground "#a8a8a8")
-    (((class color) (min-colors 88) (background light))
-     :background "#505050" :foreground "#505050")
+  '((((class color) (min-colors 88) (background dark)) :background "#a8a8a8")
+    (((class color) (min-colors 88) (background light)) :background "#505050")
     (t :background "gray"))
   "The background color is used for the scrollbar indicator.")
 
@@ -241,25 +239,8 @@ See also the settings `corfu-auto-delay', `corfu-auto-prefix' and
   "Face used for deprecated candidates.")
 
 (define-fringe-bitmap 'corfu-scroll-bar
-  (vector
-   #b11111111111111
-   #b11111111111111
-   #b11111111111111
-   #b11111111111111
-   #b11111111111111
-   #b11111111111111
-   #b11111111111111
-   #b11111111111111
-   #b11111111111111
-   #b11111111111111
-   #b11111111111111
-   #b11111111111111
-   #b11111111111111
-   #b11111111111111
-   #b11111111111111
-   #b11111111111111
-   )
-  255 16 '(center . t))
+  (vector #b0)
+  255 16 '(center t))
 
 (defvar-keymap corfu-mode-map
   :doc "Keymap used when `corfu-mode' is active.")

--- a/extensions/corfu-popupinfo.el
+++ b/extensions/corfu-popupinfo.el
@@ -371,8 +371,7 @@ form (X Y WIDTH HEIGHT DIR)."
                            (corfu-popupinfo--size)
                          (cons
                           (- (frame-pixel-width corfu-popupinfo--frame) border border)
-                          (- (frame-pixel-height corfu-popupinfo--frame) border border)))))
-                     (margin-quirk (not corfu-popupinfo--frame)))
+                          (- (frame-pixel-height corfu-popupinfo--frame) border border))))))
           (setq corfu-popupinfo--frame
                 (corfu--make-frame corfu-popupinfo--frame
                                    area-x area-y area-w area-h
@@ -380,14 +379,7 @@ form (X Y WIDTH HEIGHT DIR)."
                 corfu-popupinfo--toggle t
                 corfu-popupinfo--lock-dir area-d
                 corfu-popupinfo--candidate candidate
-                corfu-popupinfo--coordinates new-coords)
-          ;; XXX HACK: Force margin update. For some reason, the call to
-          ;; `set-window-buffer' in `corfu--make-frame' is not effective the
-          ;; first time. Why does Emacs have all these quirks?
-          (when margin-quirk
-            (set-window-buffer
-             (frame-root-window corfu-popupinfo--frame)
-             " *corfu-popupinfo*")))))))
+                corfu-popupinfo--coordinates new-coords))))))
 
 (defun corfu-popupinfo--hide ()
   "Clear the info popup buffer content and hide it."


### PR DESCRIPTION
# Introduction

Historically there seems to be a number of alignment problems with Corfu due to differences of font widths in different substrings within the completion strings, this often clash with the desire to align the prompt right below the beginning of the string to complete, which resulted in some unusual function signatures and yet the problem still remains.

## Problem 1
<img width="927" alt="Screenshot 2024-10-19 at 5 38 06 PM" src="https://github.com/user-attachments/assets/30cb8c81-1517-47f2-890a-803ceaaa11c7">

When using `corfu-margin-formatters` or `:affixation-function`, the returned icon may be an image that has a different width from the buffer default font width. Currently corfu simply multiplies the maximum string widths calculated as the number of columns required in `corfu--format-candidates`, and the `default-font-width` of the buffer together. This assumes every glyph in the strings has the same width, which may not be the case when customizing any of `corfu-margin-formatters`, `:affixation-function` or `:annotation-function`. The result is the final width calculation, which is in pixels, is off by the difference of the number of pixels between the icon image widths and the default font widths multiplied by the number of glyphs in these different widths, resulting in the annotation being cut off.

## Problem 2
<img width="545" alt="Screenshot 2024-10-19 at 5 40 33 PM" src="https://github.com/user-attachments/assets/60306566-0599-4460-988a-fe0543ce7d62">

In order to align the prompt to the beginning of the string to complete,  a prefix width denoted in the number of columns is used to calculate an offset, similar to problem 1, results in the wrong popup width calculation, so the prefix offset is also off by the difference between the default font width and the pixel width of the actual images.

## Problem 3
<img width="545" alt="Screenshot 2024-10-19 at 5 43 26 PM" src="https://github.com/user-attachments/assets/32079ca3-d140-444c-a92d-a6da34fe8623">

`corfu-left-margin-width` is set to 0 regardless of whether the curried margin formatter function actually returned a non-empty string, which also leads to the left margin of the popup being removed.

## Problem 4
<img width="545" alt="Screenshot 2024-10-19 at 5 46 52 PM" src="https://github.com/user-attachments/assets/82fc43d9-0d5d-412b-b972-e77a99bc042a">


If the completion candidate itself contains an emoji, similar to problem 1, in addition to the width of the candidate string is wrong, now even the height is wrong (nothing we can do about the pixel height tho, it's an Emacs limitation for emacs-devel to solve).

## Problem 5

Overly long strings are truncated without ellipses to indicate truncation, and/or the padding between the candidate and the suffix are uneven.

<img width="545" alt="Screenshot 2024-10-19 at 5 49 18 PM" src="https://github.com/user-attachments/assets/73c9af5a-31b6-4018-a0af-8007b25c1bfd">
<img width="545" alt="Screenshot 2024-10-19 at 5 50 19 PM" src="https://github.com/user-attachments/assets/0ee1abb8-fc42-409b-a33b-e1b2f1fc085e">
<img width="545" alt="Screenshot 2024-10-19 at 5 50 32 PM" src="https://github.com/user-attachments/assets/c2580a03-f335-4f76-ac66-c42ef210e0e4">

Even after truncating the suffix, the completion candidate string itself + prefix can still be longer than max-width, but the candidate string is not truncated.

<img width="545" alt="Screenshot 2024-10-19 at 5 50 02 PM" src="https://github.com/user-attachments/assets/4414e24a-0057-4823-b30b-aae8d2e6bbd8">


## Problem 6

Padding is wrong if any of prefix, candidate or suffix use a variable font.

<img width="545" alt="Screenshot 2024-10-19 at 5 56 58 PM" src="https://github.com/user-attachments/assets/658caabe-285a-4c2f-b201-368a4b2e9942">


## Solution

Let `corfu--affixate` apply the margin formatters / affixation function / annotation function only. Return only a list of triples of strings.

Let `corfu--format-candidates` format, pad, and truncate the completion strings by pixels. Candidate strings and suffixes are truncated individually with pixel-based padding in between. Return only the final list of formatted strings.

Recalculate the string pixel widths for the prefix and the completion strings before calling `corfu--popup-show`, which should calculate the final pixel widths needed for the popup using the passed in prefix and candidate widths, now in pixels, directly without pretending every character in the strings having uniform widths.

Recalculate truncations and padding for the current candidate as a customized `corfu-current` face may also affect pixel widths.

## Final result

<img width="658" alt="Screenshot 2024-10-19 at 6 00 49 PM" src="https://github.com/user-attachments/assets/4247e61b-ebd4-40d9-8bea-ebd1f9d5333f">
<img width="658" alt="Screenshot 2024-10-19 at 6 01 14 PM" src="https://github.com/user-attachments/assets/05dbf322-8de2-467d-830d-1c9bde1a2d3a">
<img width="658" alt="Screenshot 2024-10-19 at 6 01 46 PM" src="https://github.com/user-attachments/assets/29246ebe-b0e8-4c4d-97f2-9123f2687a15">
<img width="658" alt="Screenshot 2024-10-19 at 6 01 56 PM" src="https://github.com/user-attachments/assets/07ccf8d6-e85f-4a65-b56a-951519c0fab8">
<img width="548" alt="Screenshot 2024-10-19 at 6 03 04 PM" src="https://github.com/user-attachments/assets/588bbca9-c25e-4afb-933f-4584c6286c03">
<img width="548" alt="Screenshot 2024-10-19 at 6 04 48 PM" src="https://github.com/user-attachments/assets/323563e2-c11b-46ec-bac8-50d8c782da39">
<img width="548" alt="Screenshot 2024-10-19 at 6 05 43 PM" src="https://github.com/user-attachments/assets/19d00f27-3a01-4003-8873-d90026bb2143">
<img width="548" alt="Screenshot 2024-10-19 at 6 07 09 PM" src="https://github.com/user-attachments/assets/e4d81402-5447-47f8-bc69-ab05571f5e63">
<img width="548" alt="Screenshot 2024-10-19 at 6 07 27 PM" src="https://github.com/user-attachments/assets/95d4c908-1553-455d-a79a-cb029528c4b5">
<img width="548" alt="Screenshot 2024-10-19 at 6 07 45 PM" src="https://github.com/user-attachments/assets/d681ec73-92a1-4e6b-a84e-fb11e06ea4ae">


## Follow up

corfu-terminal will be broken by this PR, but I'll file a PR over there.