### PR TITLE
format-candidates: ensure suffix is right-aligned when possible

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -741,9 +741,10 @@ FRAME is the existing frame."
                     (concat
                      prefix (make-string (- pw (string-width prefix)) ?\s)
                      cand
-                     (make-string (max 1 (- width pw (string-width cand)
-					    (string-width suffix)))
-				  ?\s)
+                     (when (> sw 0)
+                       (make-string (max 0 (- width pw (string-width cand)
+                                              (string-width suffix)))
+                                    ?\s))
                      suffix)
                     width)))))
 

--- a/corfu.el
+++ b/corfu.el
@@ -734,23 +734,16 @@ FRAME is the existing frame."
          (width (+ pw cw sw))
          ;; -4 because of margins and some additional safety
          (max-width (min corfu-max-width (- (frame-width) 4))))
-    (when (> width max-width)
-      (setq sw (max 0 (- max-width pw cw))
-            width (+ pw cw sw)))
-    (when (< width corfu-min-width)
-      (setq cw (+ cw (- corfu-min-width width))
-            width corfu-min-width))
-    (setq width (min width max-width))
+    (setq width (min (max corfu-min-width width) max-width))
     (list pw width
           (cl-loop for (cand prefix suffix) in cands collect
                    (truncate-string-to-width
                     (concat
-                     prefix (make-string (max 0 (- pw (string-width prefix))) ?\s)
+                     prefix (make-string (- pw (string-width prefix)) ?\s)
                      cand
-                     (when (/= sw 0)
-                       (make-string (+ (max 0 (- cw (string-width cand)))
-                                       (max 0 (- sw (string-width suffix))))
-                                    ?\s))
+                     (make-string (max 1 (- width pw (string-width cand)
+					    (string-width suffix)))
+				  ?\s)
                      suffix)
                     width)))))
 


### PR DESCRIPTION
This small PR corrects the bug found in #508 related to "staggered" suffix placement.  It turns out this occurs only when at least one visible candidate and its prefix exceeds `corfu-max-width`, in which case _no_ padding was being applied to the suffix for visible candidates. 

This PR also simplifies suffix placement to right-align it when possible, and truncate it when not possible, resulting in the suffix appearing more often even when `corfu-max-width` is relatively small.

Only normal `string-width` is used, no pixel measurement. 

## Examples 

With `corfu-max-width=24`.

### Normal

| Main | This PR |
|--|--|
|<img width="240" alt="image" src="https://github.com/user-attachments/assets/c6771eb6-1ef2-45d9-bc7c-aa1203bc841c"> | <img width="235" alt="image" src="https://github.com/user-attachments/assets/742841da-3807-4654-93d6-186d54d711d1"> |

Current suffix placement loses most information.  This PR right-aligns suffix on all lines where this is possible.

### Suffix Bug Condition

| Main | This PR |
|--|--|
| <img width="234" alt="image" src="https://github.com/user-attachments/assets/6f11ba09-e40a-4a78-aa46-2d55752e83a3"> | <img width="235" alt="image" src="https://github.com/user-attachments/assets/75ad023e-b2dc-48e0-8df8-a79d8838e4ea"> |

When an overfull line comes into view, currently no suffix padding is used, resulting in staggered layout [^1].  This PR maintains proper right-alignment.

[^1]: Note that eglot, the completion provider, is adding a space at the beginning of its suffixes.