### PR TITLE
Use fringe for the scroll bar

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -479,7 +479,8 @@ FRAME is the existing frame."
     ;; overrides the parameter `tool-bar-lines' for every frame, including child
     ;; frames.  The child frame API is a pleasure to work with.  It is full of
     ;; lovely surprises.
-    (let* ((is (frame-parameters frame))
+    (let* ((win (frame-root-window frame))
+           (is (frame-parameters frame))
            (should `((background-color
                       . ,(face-attribute 'corfu-default :background nil 'default))
                      (font . ,(frame-parameter parent 'font))
@@ -488,9 +489,9 @@ FRAME is the existing frame."
                      ,@corfu--frame-parameters))
            (diff (cl-loop for p in should for (k . v) = p
                           unless (equal (alist-get k is) v) collect p)))
-      (when diff (modify-frame-parameters frame diff)))
-    (let ((win (frame-root-window frame)))
-      (unless (eq (window-buffer win) (current-buffer))
+      (when diff (modify-frame-parameters frame diff))
+      ;; XXX HACK: `set-window-buffer' must be called to force fringe update.
+      (when (or diff (eq (window-buffer win) (current-buffer)))
         (set-window-buffer win (current-buffer)))
       ;; Disallow selection of root window (gh:minad/corfu#63)
       (set-window-parameter win 'no-delete-other-windows t)

--- a/corfu.el
+++ b/corfu.el
@@ -326,8 +326,6 @@ See also the settings `corfu-auto-delay', `corfu-auto-prefix' and
     (outer-border-width . 0)
     (internal-border-width . 1)
     (child-frame-border-width . 1)
-    (left-fringe . 0)
-    (right-fringe . 0)
     (vertical-scroll-bars . nil)
     (horizontal-scroll-bars . nil)
     (menu-bar-lines . 0)
@@ -352,12 +350,12 @@ See also the settings `corfu-auto-delay', `corfu-auto-prefix' and
     (cursor-type . nil)
     (show-trailing-whitespace . nil)
     (display-line-numbers . nil)
-    (left-fringe-width . nil)
-    (right-fringe-width . nil)
+    (left-fringe-width . 0)
+    (right-fringe-width . 0)
     (left-margin-width . 0)
     (right-margin-width . 0)
     (fringes-outside-margins . 0)
-    (fringe-indicator-alist . nil)
+    (fringe-indicator-alist (continuation) (truncation))
     (indicate-empty-lines . nil)
     (indicate-buffer-boundaries . nil)
     (buffer-read-only . t))
@@ -462,6 +460,8 @@ FRAME is the existing frame."
                    `((parent-frame . ,parent)
                      (minibuffer . ,(minibuffer-window parent))
                      (width . 0) (height . 0) (visibility . nil)
+                     (right-fringe . ,right-fringe-width)
+                     (left-fringe . ,left-fringe-width)
                      ,@corfu--frame-parameters))))
     ;; XXX HACK Setting the same frame-parameter/face-background is not a nop.
     ;; Check before applying the setting. Without the check, the frame flickers
@@ -483,6 +483,8 @@ FRAME is the existing frame."
            (should `((background-color
                       . ,(face-attribute 'corfu-default :background nil 'default))
                      (font . ,(frame-parameter parent 'font))
+                     (right-fringe . ,right-fringe-width)
+                     (left-fringe . ,left-fringe-width)
                      ,@corfu--frame-parameters))
            (diff (cl-loop for p in should for (k . v) = p
                           unless (equal (alist-get k is) v) collect p)))
@@ -1021,15 +1023,18 @@ A scroll bar is displayed from LO to LO+BAR."
     (with-current-buffer (corfu--make-buffer " *corfu*")
       (let* ((ch (default-line-height))
              (cw (default-font-width))
+             (bw (ceiling (* cw corfu-bar-width)))
+             (fringe (display-graphic-p))
              (ml (ceiling (* cw corfu-left-margin-width)))
              (mr (ceiling (* cw corfu-right-margin-width)))
-             (bw (ceiling (min mr (* cw corfu-bar-width))))
              (marginl (and (> ml 0) (propertize " " 'display `(space :width (,ml)))))
-             (sbar (when (> bw 0)
+             (sbar (if fringe
+                       #(" " 0 1 (display (right-fringe corfu--bar corfu-bar)))
                      (concat (propertize " " 'display `(space :align-to (- right (,bw))))
                              (propertize " " 'face 'corfu-bar 'display `(space :width (,bw))))))
+             (cbar (and fringe #(" " 0 1 (display (right-fringe corfu--bar corfu-current)))))
              (pos (posn-x-y pos))
-             (width (+ (* width cw) ml mr))
+             (width (+ (* width cw) ml mr (if fringe (- bw) 0)))
              ;; XXX HACK: Minimum popup height must be at least 1 line of the
              ;; parent frame (gh:minad/corfu#261).
              (height (max lh (* (length lines) ch)))
@@ -1042,13 +1047,17 @@ A scroll bar is displayed from LO to LO+BAR."
                     (- yb height lh border border)
                   yb))
              (row 0))
+        (setq right-fringe-width (if fringe bw 0))
+        (when (and (> right-fringe-width 0) (not (fringe-bitmap-p 'corfu--bar)))
+          (define-fringe-bitmap 'corfu--bar []))
         (with-silent-modifications
           (erase-buffer)
           (apply #'insert
            (cl-loop for line in lines collect
                     (let ((str (concat
                                 marginl line
-                                (and lo (<= lo row (+ lo bar)) sbar)
+                                (or (and lo (<= lo row (+ lo bar)) sbar)
+                                    (and (= row curr) cbar))
                                 "\n")))
                       (when (= row curr)
                         (add-face-text-property

--- a/corfu.el
+++ b/corfu.el
@@ -1023,10 +1023,10 @@ A scroll bar is displayed from LO to LO+BAR."
     (with-current-buffer (corfu--make-buffer " *corfu*")
       (let* ((ch (default-line-height))
              (cw (default-font-width))
-             (bw (ceiling (* cw corfu-bar-width)))
              (fringe (display-graphic-p))
              (ml (ceiling (* cw corfu-left-margin-width)))
-             (mr (ceiling (* cw corfu-right-margin-width)))
+             (bw (ceiling (* cw corfu-bar-width)))
+             (mr (max bw (ceiling (* cw corfu-right-margin-width))))
              (marginl (and (> ml 0) (propertize " " 'display `(space :width (,ml)))))
              (sbar (if fringe
                        #(" " 0 1 (display (right-fringe corfu--bar corfu-bar)))

--- a/extensions/corfu-popupinfo.el
+++ b/extensions/corfu-popupinfo.el
@@ -130,7 +130,6 @@ documentation from the backend is usually expensive."
     (left-margin-width . 1)
     (right-margin-width . 1)
     (word-wrap . t)
-    (fringe-indicator-alist (continuation))
     (char-property-alias-alist (face font-lock-face)))
   "Buffer parameters.")
 


### PR DESCRIPTION
This ensures that the scroll bar is always visible, even if wide characters lead to truncation of the popup content. Before this change, the scroll bar could be pushed out of the window by the content.

This PR can be tested for example with cape-emoji where the emojis in the annotation are wider than the fixed width characters.

~The problem with this PR is that it breaks the terminal scrollbar. Therefore probably the old code has to be kept and only on GUI (fringe-bitmap-p function available) the fringe should be used.~ (EDIT: Fixed now)

cc @jdtsmith