### PR TITLE
Avoid truncate-string-to-width

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -5,13 +5,9 @@
 * Development
 
 - Require Emacs 28.1.
-- Use fringe to display scroll bar. Make sure that the scroll bar cannot be
-  pushed outside the child frame by the content. This affects for example
-  ~cape-emoji~.
-- New face ~corfu-scroll-bar~ which replaces the old face ~corfu-bar~. For technical
-  reasons the foreground color is used for the scroll bar, and not the
-  background as for the old face.
-- Renamed ~corfu-bar-width~ to ~corfu-scroll-bar-width~ for consistency.
+- Use fringe to display scroll bar. This change improves performance and makes
+  sure that the scroll bar cannot be pushed outside the child frame by the
+  content. This affects for example ~cape-emoji~.
 - Improve suffix alignment.
 
 * Version 1.5 (2024-07-26)

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -8,6 +8,10 @@
 - Use fringe to display scroll bar. Make sure that the scroll bar cannot be
   pushed outside the child frame by the content. This affects for example
   ~cape-emoji~.
+- New face ~corfu-scroll-bar~ which replaces the old face ~corfu-bar~. For technical
+  reasons the foreground color is used for the scroll bar, and not the
+  background as for the old face.
+- Renamed ~corfu-bar-width~ to ~corfu-scroll-bar-width~ for consistency.
 - Improve suffix alignment.
 
 * Version 1.5 (2024-07-26)

--- a/corfu.el
+++ b/corfu.el
@@ -744,16 +744,14 @@ FRAME is the existing frame."
     (setq width (min (max corfu-min-width width) max-width))
     (list pw width
           (cl-loop for (cand prefix suffix) in cands collect
-                   (truncate-string-to-width
-                    (concat
-                     prefix (make-string (- pw (string-width prefix)) ?\s)
-                     cand
-                     (when (> sw 0)
-                       (make-string (max 0 (- width pw (string-width cand)
-                                              (string-width suffix)))
-                                    ?\s))
-                     suffix)
-                    width)))))
+                   (concat
+                    prefix (make-string (- pw (string-width prefix)) ?\s)
+                    cand
+                    (when (> sw 0)
+                      (make-string (max 0 (- width pw (string-width cand)
+                                             (string-width suffix)))
+                                   ?\s))
+                    suffix)))))
 
 (defun corfu--compute-scroll ()
   "Compute new scroll position."
@@ -1028,17 +1026,17 @@ A scroll bar is displayed from LO to LO+BAR."
                              (propertize " " 'face 'corfu-bar 'display `(space :width (,bw))))))
              (cbar (and fringe #(" " 0 1 (display (right-fringe corfu--bar corfu-current)))))
              (pos (posn-x-y pos))
-             (width (+ (* width cw) ml mr (if fringe (- bw) 0)))
+             (pwidth (+ (* width cw) ml mr (if fringe (- bw) 0)))
              ;; XXX HACK: Minimum popup height must be at least 1 line of the
              ;; parent frame (gh:minad/corfu#261).
-             (height (max lh (* (length lines) ch)))
+             (pheight (max lh (* (length lines) ch)))
              (edge (window-inside-pixel-edges))
              (border (alist-get 'internal-border-width corfu--frame-parameters))
              (x (max 0 (min (+ (car edge) (- (or (car pos) 0) ml (* cw off) border))
-                            (- (frame-pixel-width) width))))
+                            (- (frame-pixel-width) pwidth))))
              (yb (+ (cadr edge) (window-tab-line-height) (or (cdr pos) 0) lh))
              (y (if (> (+ yb (* corfu-count ch) lh lh) (frame-pixel-height))
-                    (- yb height lh border border)
+                    (- yb pheight lh border border)
                   yb))
              (row 0))
         (setq right-fringe-width (if fringe bw 0))
@@ -1049,7 +1047,8 @@ A scroll bar is displayed from LO to LO+BAR."
           (apply #'insert
            (cl-loop for line in lines collect
                     (let ((str (concat
-                                marginl line
+                                marginl
+                                (if fringe line (truncate-string-to-width line width))
                                 (or (and lo (<= lo row (+ lo bar)) sbar)
                                     (and (eq row curr) cbar))
                                 "\n")))
@@ -1059,7 +1058,7 @@ A scroll bar is displayed from LO to LO+BAR."
                       (cl-incf row)
                       str)))
           (goto-char (point-min)))
-        (setq corfu--frame (corfu--make-frame corfu--frame x y width height))))))
+        (setq corfu--frame (corfu--make-frame corfu--frame x y pwidth pheight))))))
 
 (cl-defgeneric corfu--popup-hide ()
   "Hide Corfu popup."

--- a/corfu.el
+++ b/corfu.el
@@ -1016,8 +1016,11 @@ A scroll bar is displayed from LO to LO+BAR."
     (with-current-buffer (corfu--make-buffer " *corfu*")
       (let* ((ch (default-line-height))
              (cw (default-font-width))
-             ;; Even for larger fringes, fringe bitmaps can only have a width
-             ;; between 1 and 16. Therefore restrict the fringe width to 16.
+             ;; NOTE: Even for larger fringes, fringe bitmaps can only have a
+             ;; width between 1 and 16. Therefore we restrict the fringe width
+             ;; to 16 pixel. This restriction may cause problem on HDPi systems.
+             ;; Hopefully Emacs will adopt larger fringe bitmaps in the future
+             ;; and lift the 16 pixel restriction.
              (ml (min 16 (ceiling (* cw corfu-left-margin-width))))
              (mr (min 16 (ceiling (* cw corfu-right-margin-width))))
              (bw (min mr (ceiling (* cw corfu-bar-width))))

--- a/corfu.el
+++ b/corfu.el
@@ -1020,19 +1020,22 @@ A scroll bar is displayed from LO to LO+BAR."
              (ml (min 16 (ceiling (* cw corfu-left-margin-width))))
              (mr (min 16 (ceiling (* cw corfu-right-margin-width))))
              (bw (min mr (ceiling (* cw corfu-scroll-bar-width))))
-             (marginl (and (> ml 0) (propertize " " 'display `(space :width (,ml)))))
              (fringe (display-graphic-p))
+             (marginl (and (not fringe) (propertize " " 'display `(space :width (,ml)))))
              (sbar (if fringe
                        #(" " 0 1 (display (right-fringe corfu--bar corfu-scroll-bar)))
                      (concat (propertize " " 'display `(space :align-to (- right (,bw))))
                              (propertize " " 'face '(:inherit corfu-scroll-bar :inverse-video t)
                                          'display `(space :width (,bw))))))
              (cbar (if fringe
-                       #(" " 0 1 (display (right-fringe corfu--bar corfu--bar-cur)))
+                       #("  " 0 1 (display (left-fringe corfu--nil corfu-current))
+                         1 2 (display (right-fringe corfu--bar corfu--bar-cur)))
                      sbar))
-             (cmargin (and fringe #(" " 0 1 (display (right-fringe corfu--nil corfu-current)))))
+             (cmargin (and fringe
+                           #("  " 0 1 (display (left-fringe corfu--nil corfu-current))
+                             1 2 (display (right-fringe corfu--nil corfu-current)))))
              (pos (posn-x-y pos))
-             (pwidth (+ (* width cw) ml (if fringe 0 mr)))
+             (pwidth (+ (* width cw) (if fringe 0 (+ ml mr))))
              ;; XXX HACK: Minimum popup height must be at least 1 line of the
              ;; parent frame (gh:minad/corfu#261).
              (pheight (max lh (* (length lines) ch)))
@@ -1046,7 +1049,7 @@ A scroll bar is displayed from LO to LO+BAR."
                   yb))
              (row 0)
              (bmp (logxor (1- (ash 1 mr)) (1- (ash 1 bw)))))
-        (setq right-fringe-width (if fringe mr 0))
+        (setq left-fringe-width (if fringe ml 0) right-fringe-width (if fringe mr 0))
         (unless (or (= right-fringe-width 0) (eq (get 'corfu--bar 'corfu--bmp) bmp))
           (put 'corfu--bar 'corfu--bmp bmp)
           (define-fringe-bitmap 'corfu--bar (vector (lognot bmp)) 1 mr '(top periodic))


### PR DESCRIPTION
1. The first commit avoids `truncate-string-to-width` if the fringe is used for the scrollbar. The first commit can be checked separately to see how the result looks without the second step.
2. The second commit additionally moves the margin into the fringe too, such that the truncated text doesn't leak into the margin. I am not entirely happy with the way this is implemented.

EDIT: Turns out that fringe bitmaps have a width restriction, which makes 2. infeasible. So maybe use only 1. But there the margin is effectively lost.

EDIT2: The result works reasonably well now. The fringe/margin is restricted to 16 pixel. The existing configuration variables and faces are also preserved as is.

cc @jdtsmith  