### PR TITLE
Clean up preview overlay after quitting out of pre-command hook

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -81,8 +81,7 @@ The value should lie between 0 and corfu-count/2."
   :type '(choice (const insert) (const show) (const quit) (const nil)))
 
 (defcustom corfu-continue-commands
-  ;; nil is undefined command
-  '(nil ignore universal-argument universal-argument-more digit-argument
+  '(ignore universal-argument universal-argument-more digit-argument
     "\\`corfu-" "\\`scroll-other-window")
   "Continue Corfu completion after executing these commands.
 The list can container either command symbols or regular expressions."


### PR DESCRIPTION
<img width="544" alt="Screenshot 2024-11-26 at 8 47 59 AM" src="https://github.com/user-attachments/assets/7f7e5255-f94a-41b7-ade2-24c0d0601b89">

Sometimes, when typing C-g fast enough, it is possible to quit in such a way that the pre-command hook `corfu--prepare` is not run at all, even when a binding for C-g is in effect in `corfu-map`. When that is the case, the preview overlay is not cleaned up, but the post-command hook `corfu--post-command` will still be run with a `nil` bound to `this-command`, which presently is listed in `corfu-continue-commands`, which will cause `corfu--exhibit` to create a new preview overlay while losing the reference to the existing preview overlay. This means now there are 2 preview overlays. I have added log messages at the very beginning of `corfu--post-command`, `corfu--prepare`, `corfu--exhibit` and `corfu--teardown` to demonstrate this problem. The logs are attached below. Since it appears `this-command` is only nil after quitting, I think removing it from `corfu-continue-commands` is the easiest fix.

[bugged-quit-pre-command.log](https://github.com/user-attachments/files/17915488/bugged-quit-pre-command.log)
[fixed-quit-pre-command.log](https://github.com/user-attachments/files/17915491/fixed-quit-pre-command.log)
