### PR TITLE
Override faces from completion styles with our own in preview

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -210,6 +210,10 @@ settings `corfu-auto-delay', `corfu-auto-prefix' and
     (t :background "gray"))
   "Default face, foreground and background colors used for the popup.")
 
+(defface corfu-preview
+  '((t :inherit corfu-default))
+  "Face used for the candidate preview.")
+
 (defface corfu-current
   '((((class color) (min-colors 88) (background dark))
      :background "#00415e" :foreground "white" :extend t)
@@ -839,7 +843,7 @@ the last command must be listed in `corfu-continue-commands'."
     (overlay-put corfu--preview-ov 'priority 1000)
     (overlay-put corfu--preview-ov 'window (selected-window))
     (overlay-put corfu--preview-ov (if (= beg end) 'after-string 'display)
-                 (nth corfu--index corfu--candidates))))
+                 (propertize (nth corfu--index corfu--candidates) 'face 'corfu-preview))))
 
 (defun corfu--preview-delete ()
   "Delete the preview overlay."


### PR DESCRIPTION
Some completion styles like corfu-prescient will apply faces to the candidate strings deep inside the completion-in-region machinery before corfu gets to them. While these faces are useful in the completion popup, they aren't so useful in the preview. This is evident in the first screenshot in the [README](https://github.com/minad/corfu/raw/screenshots/light.png?raw=true), here's another example in TypeScript where they make even less sense.

![ScreenRecording2024-12-08at5 49 27PM-ezgif com-optipng](https://github.com/user-attachments/assets/06a00afb-f9c0-4396-886f-7890e70480ad)

This PR makes a copy of the candidate string and overrides the face property with a new face that by default inherits from corfu-default, so the user can customize the face if they so choose.
![ScreenRecording2024-12-08at5 58 11PM-ezgif com-optipng](https://github.com/user-attachments/assets/d8691770-9aab-4988-855c-bd38d2b42464)


