### PR TITLE
README: minor fix for example configuration

### DIFF
--- a/README.org
+++ b/README.org
@@ -130,7 +130,7 @@ Here is an example configuration:
   ;; Recommended: Enable Corfu globally.  This is recommended since Dabbrev can
   ;; be used globally (M-/).  See also the customization variable
   ;; `global-corfu-modes' to exclude certain modes.
-  :init
+  :config
   (global-corfu-mode))
 
 ;; A few more useful configurations...


### PR DESCRIPTION
Using :init to call ‘global-corfu-mode’ will fail if the package has not yet been loaded.