### PR TITLE
Use local image instead of links in README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -32,13 +32,13 @@ completion utilities are provided by the separate [[https://github.com/minad/cap
 frames also for terminal Emacs. On older Emacs versions, you can use the
 [[https://codeberg.org/akib/emacs-corfu-terminal][corfu-terminal]] package.
 
-#+html: <img src="https://github.com/minad/corfu/blob/screenshots/light.png?raw=true">
+[[file:light.png]]
 
-#+html: <img src="https://github.com/minad/corfu/blob/screenshots/dark.png?raw=true">
+[[file:dark.png]]
 
-#+html: <img src="https://github.com/minad/corfu/blob/screenshots/popupinfo-light.png?raw=true">
+[[file:popupinfo-light.png]]
 
-#+html: <img src="https://github.com/minad/corfu/blob/screenshots/popupinfo-dark.png?raw=true">
+[[file:popupinfo-dark.png]]
 
 #+toc: headlines 8
 


### PR DESCRIPTION
* This makes it less of a round trip to get the images
* The patch was originally authored by Martin <debacle@debian.org>
  - https://salsa.debian.org/emacsen-team/emacs-corfu/-/commit/c569533e8f2e0bf51ed02ad7e83b88aeb38e759d