### PR TITLE
Define default foreground color for dark background

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -205,7 +205,7 @@ settings `corfu-auto-delay', `corfu-auto-prefix' and
   :group 'faces)
 
 (defface corfu-default
-  '((((class color) (min-colors 88) (background dark)) :background "#191a1b")
+  '((((class color) (min-colors 88) (background dark)) :background "#191a1b" :foreground "white")
     (((class color) (min-colors 88) (background light)) :background "#f0f0f0")
     (t :background "gray"))
   "Default face, foreground and background colors used for the popup.")


### PR DESCRIPTION
Fixes #556

This results in a default of:
![image](https://github.com/user-attachments/assets/f557f935-e145-42d4-b281-abed8da4159b)
