### PR TITLE
Add escaping commands for corfu-separator

### DIFF
--- a/README.org
+++ b/README.org
@@ -393,6 +393,13 @@ Then, when a new orderless component is desired, use =M-SPC=
 and arbitrary orderless search terms and new separators can be entered
 thereafter.
 
+Alternatively, bind ~corfu-insert-or-escape-separator~ in place of
+~corfu-insert-separator~ to be able to escape and/or remove the separator
+indefinitely by repeating the bound key sequence. Or keep using
+~corfu-insert-separator~ and also bind ~corfu-escape-separator~, which only
+escapes/unescapes indefinitely, thus skipping one state in the loop since in
+this case a key is dedicated for insertion.
+
 To treat the entire input as Orderless input, you can set the customization
 option ~corfu-quit-at-boundary~ to nil. This disables the predicate which checks
 if the current completion boundary has been left. In contrast, if you always

--- a/corfu.el
+++ b/corfu.el
@@ -1289,6 +1289,48 @@ prompt instead.  See `corfu-separator' for more details."
                 (= (char-before) corfu-separator))
       (insert corfu-separator))))
 
+(defun corfu-insert-or-escape-separator ()
+  "Rotate prompt between inserting, escaping and removing the separator.
+An alternative to `corfu-insert-separator', useful in cases where including the
+separator in the query is important, and the user wants a single bind for
+everything. It can be called repeatedly, and will do, in order (starting from a
+prompt without any separators):
+
+1. Insert the separator character at prompt end.
+2. Insert a backslash character before the inserted separator, to treat it as
+   part of the prompt instead of as a split point for components.
+3. Remove the separator and backslash.
+
+The sequence will loop to 1 if called further, allowing to fix accidental
+changes to the prompt. Note this function can remove the separator character."
+  (interactive)
+  (if (char-equal (char-before) corfu-separator)
+      (if (char-equal (char-before (1- (point))) ?\\)
+          (save-excursion (delete-char -2))                   ;; Case 3
+        (save-excursion (backward-char 1) (insert-char ?\\))) ;; Case 2
+    (call-interactively #'corfu-insert-separator)))           ;; Case 1
+
+(defun corfu-escape-separator ()
+  "Rotate prompt between escaping and unescaping the separator.
+A complement to `corfu-insert-separator', useful in cases where including the
+separator in the query is important, and the user wants escaping to be separate
+from inserting. It can be called repeatedly, and will do, in order:
+
+0. (when there is no separator) Insert the separator character at prompt end.
+1. Insert a backslash character before the already present separator, to treat
+   it as part of the prompt instead of as a split point for components.
+2. Remove the backslash.
+
+The sequence will loop to 1 if called further, allowing to fix accidental
+changes to the prompt. Note this function cannot remove the separator
+character."
+  (interactive)
+  (if (char-equal (char-before) corfu-separator)
+      (if (char-equal (char-before (1- (point))) ?\\)
+          (save-excursion (backward-char 1) (delete-char -1)) ;; Case 2
+        (save-excursion (backward-char 1) (insert-char ?\\))) ;; Case 1
+    (call-interactively #'corfu-insert-separator)))           ;; Case 0
+
 (defun corfu-next (&optional n)
   "Go forward N candidates."
   (interactive "p")

--- a/corfu.el
+++ b/corfu.el
@@ -82,6 +82,7 @@ The value should lie between 0 and corfu-count/2."
 
 (defcustom corfu-continue-commands
   '(ignore universal-argument universal-argument-more digit-argument
+    corfu-insert-or-escape-separator corfu-escape-separator
     "\\`corfu-" "\\`scroll-other-window")
   "Continue Corfu completion after executing these commands.
 The list can container either command symbols or regular expressions."
@@ -1526,7 +1527,8 @@ local `completion-at-point-functions'."
 ;; Do not show Corfu commands with M-X
 (dolist (sym '( corfu-next corfu-previous corfu-first corfu-last corfu-quit corfu-reset
                 corfu-complete corfu-insert corfu-scroll-up corfu-scroll-down corfu-expand
-                corfu-send corfu-insert-separator corfu-prompt-beginning corfu-prompt-end
+                corfu-send corfu-insert-separator corfu-insert-or-escape-separator
+                corfu-escape-separator corfu-prompt-beginning corfu-prompt-end
                 corfu-info-location corfu-info-documentation ;; autoloads in corfu-info.el
                 corfu-quick-jump corfu-quick-insert corfu-quick-complete)) ;; autoloads in corfu-quick.el
   (put sym 'completion-predicate #'ignore))


### PR DESCRIPTION
There are 2 new functions provided:

1. `corfu-insert-or-escape-separator` works exactly like Doom Emacs' +corfu/smart-sep-toggle-escape, meant to replace corfu-insert-separator when the user wants an insert/escape all-in-one solution. The code was refactored and looks very different, though.
2. `corfu-escape-separator` is provided as an addition to `corfu-insert-separator`, meant to be bound to another key. It never removes the separator, only the backslash. It may insert a separator if not there. This is for the user who wants to think of escaping separately from inserting, saving them the extra key to reinsert the separator if only option 1 was provided.

The functions' implementation is actually really simple, most of the diff is documentation.

Both are unbound by default. Maybe it would make sense use `corfu-insert-or-escape-separator` as the default bind, but that can come separately if need be.

By the way, if you think this functionality shouldn't be provided by the core of corfu, I don't mind if the PR gets closed. I jumped to a PR because this was a quick implementation and seems reasonable to add. I can shorten the documentation if it's too verbose, as well. 