### PR TITLE
refactor: favor /*-let\*/ macros

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -450,7 +450,7 @@ is a prefix length override, which is t for manual completion."
 (defun corfu--make-frame (frame x y width height)
   "Show current buffer in child frame at X/Y with WIDTH/HEIGHT.
 FRAME is the existing frame."
-  (when-let (((frame-live-p frame))
+  (when-let* (((frame-live-p frame))
              (timer (frame-parameter frame 'corfu--hide-timer)))
     (cancel-timer timer)
     (set-frame-parameter frame 'corfu--hide-timer nil))
@@ -653,7 +653,7 @@ FRAME is the existing frame."
                (field (substring str (car bounds) (+ pt (cdr bounds))))
                (completing-file (eq (corfu--metadata-get 'category) 'file))
                (`(,all . ,hl) (corfu--filter-completions str table pred pt corfu--metadata))
-               (base (or (when-let ((z (last all))) (prog1 (cdr z) (setcdr z nil))) 0))
+               (base (or (when-let* ((z (last all))) (prog1 (cdr z) (setcdr z nil))) 0))
                (corfu--base (substring str 0 base))
                (pre nil))
     ;; Filter the ignored file extensions. We cannot use modified predicate for
@@ -897,7 +897,7 @@ the stack trace is shown in the *Messages* buffer."
 (defun corfu--exit-function (str status cands)
   "Call the `:exit-function' with STR and STATUS.
 Lookup STR in CANDS to restore text properties."
-  (when-let ((exit (plist-get completion-extra-properties :exit-function)))
+  (when-let* ((exit (plist-get completion-extra-properties :exit-function)))
     (funcall exit (or (car (member str cands)) str) status)))
 
 (defun corfu--done (str status cands)
@@ -1028,7 +1028,7 @@ See `completion-in-region' for the arguments BEG, END, TABLE, PRED."
          (`(,fun ,beg ,end ,table . ,plist)
           (let ((completion-in-region-mode-predicate
                  (lambda ()
-                   (when-let ((newbeg (car-safe (funcall fun))))
+                   (when-let* ((newbeg (car-safe (funcall fun))))
                      (= newbeg beg))))
                 (completion-extra-properties plist))
             (corfu--setup beg end table (plist-get plist :predicate))
@@ -1163,9 +1163,9 @@ A scroll bar is displayed from LO to LO+BAR."
          (mf (let ((completion-extra-properties (nth 4 completion-in-region--data)))
                (run-hook-with-args-until-success 'corfu-margin-formatters corfu--metadata))))
     (setq cands
-          (if-let ((aff (corfu--metadata-get 'affixation-function)))
+          (if-let* ((aff (corfu--metadata-get 'affixation-function)))
               (funcall aff cands)
-            (if-let ((ann (corfu--metadata-get 'annotation-function)))
+            (if-let* ((ann (corfu--metadata-get 'annotation-function)))
                 (cl-loop for cand in cands collect
                          (let ((suff (or (funcall ann cand) "")))
                            ;; The default completion UI adds the

--- a/extensions/corfu-echo.el
+++ b/extensions/corfu-echo.el
@@ -81,7 +81,7 @@ subsequent delay."
   :global t :group 'corfu)
 
 (cl-defmethod corfu--exhibit :after (&context (corfu-echo-mode (eql t)) &optional _auto)
-  (if-let (((not (minibufferp)))
+  (if-let* (((not (minibufferp)))
            (delay (if (consp corfu-echo-delay)
                       (funcall (if corfu-echo--message #'cdr #'car)
                                corfu-echo-delay)

--- a/extensions/corfu-history.el
+++ b/extensions/corfu-history.el
@@ -77,7 +77,7 @@ The shift will decay away after `corfu-history-duplicate' times
     (let ((ht (make-hash-table :test #'equal :size (length corfu-history)))
           (decay (/ -1.0 (* corfu-history-duplicate corfu-history-decay))))
       (cl-loop for elem in corfu-history for idx from 0
-               for r = (if-let ((r (gethash elem ht)))
+               for r = (if-let* ((r (gethash elem ht)))
                            ;; Reduce duplicate rank with exponential decay.
                            (- r (round (* corfu-history-duplicate (exp (* decay idx)))))
                          ;; Never outrank the most recent element.

--- a/extensions/corfu-info.el
+++ b/extensions/corfu-info.el
@@ -101,7 +101,7 @@ If called with a prefix ARG, the buffer is persistent."
              (and arg (format "*corfu loc: %s*" cand)))
           (without-restriction
             (goto-char (point-min))
-            (when-let ((pos (cdr loc)))
+            (when-let* ((pos (cdr loc)))
               (if (bufferp (car loc))
                   (goto-char pos)
                 (forward-line (1- pos))))

--- a/extensions/corfu-popupinfo.el
+++ b/extensions/corfu-popupinfo.el
@@ -181,7 +181,7 @@ all values are in pixels relative to the origin.  See
   (save-excursion
     (let ((old-buffers (buffer-list)) (buffer nil))
       (unwind-protect
-          (when-let
+          (when-let*
               ((fun (corfu--metadata-get 'company-location))
                ;; BUG: company-location may throw errors if location is not found
                (loc (ignore-errors (funcall fun candidate)))
@@ -201,7 +201,7 @@ all values are in pixels relative to the origin.  See
               (save-excursion
                 (without-restriction
                   (goto-char (point-min))
-                  (when-let ((pos (cdr loc)))
+                  (when-let* ((pos (cdr loc)))
                     (if (bufferp (car loc))
                         (goto-char pos)
                       (forward-line (1- pos))))
@@ -217,7 +217,7 @@ all values are in pixels relative to the origin.  See
 
 (defun corfu-popupinfo--get-documentation (candidate)
   "Get the documentation for CANDIDATE."
-  (when-let ((fun (corfu--metadata-get 'company-doc-buffer))
+  (when-let* ((fun (corfu--metadata-get 'company-doc-buffer))
              (res (save-excursion
                     (let ((inhibit-message t)
                           (message-log-max nil)
@@ -350,7 +350,7 @@ form (X Y WIDTH HEIGHT DIR)."
            (new-coords (frame-edges corfu--frame 'inner-edges))
            (coords-changed (not (equal new-coords corfu-popupinfo--coordinates))))
       (when cand-changed
-        (if-let ((content (funcall corfu-popupinfo--function candidate)))
+        (if-let* ((content (funcall corfu-popupinfo--function candidate)))
             (with-current-buffer (corfu--make-buffer corfu-popupinfo--buffer)
               (with-silent-modifications
                 (erase-buffer)
@@ -358,7 +358,7 @@ form (X Y WIDTH HEIGHT DIR)."
                 (goto-char (point-min)))
               (dolist (var corfu-popupinfo--buffer-parameters)
                 (set (make-local-variable (car var)) (cdr var)))
-              (when-let ((m (memq 'corfu-default (alist-get 'default face-remapping-alist))))
+              (when-let* ((m (memq 'corfu-default (alist-get 'default face-remapping-alist))))
                 (setcar m 'corfu-popupinfo)))
           (corfu-popupinfo--hide)
           (setq cand-changed nil coords-changed nil)))
@@ -486,7 +486,7 @@ not be displayed until this command is called again, even if
       (setq corfu-popupinfo--timer nil))
     (if (and (>= corfu--index 0) (corfu-popupinfo--visible-p corfu--frame))
         (let ((cand (nth corfu--index corfu--candidates)))
-          (if-let ((delay (if (consp corfu-popupinfo-delay)
+          (if-let* ((delay (if (consp corfu-popupinfo-delay)
                               (funcall (if (eq corfu-popupinfo--toggle 'init) #'car #'cdr)
                                        corfu-popupinfo-delay)
                             corfu-popupinfo-delay))


### PR DESCRIPTION
I am noticing the following in my use of 31.0.50 version of Emacs (built from HEAD of `master` branch):

> Warning: ‘if-let’ is an obsolete macro (as of 31.1); use ‘if-let*’
> instead.

And:

> Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’
> or ‘and-let*’ instead.

My understanding is that corfu requires 29.1 of Emacs.  Reviewing the 29.1 version of Emacs, the `if-let*` and `when-let*` macro is defined:

```sh
❯ cd ~/git/emacs; git checkout emacs-29.1; rg "defmacro (if|when)-let\*"
HEAD is now at a9b28224af0 ; Last-minute changes befor releasing 29.1
lisp/subr.el
2479:(defmacro if-let* (varlist then &rest else)
2493:(defmacro when-let* (varlist &rest body)
```

Thus, we should be able to swtich without breaking functionality from the `if-let` to `if-let*` and likewise for `when-let`.