### PR TITLE
fix: set delete-before frame parameter in EXWM

### DIFF
--- a/corfu.el
+++ b/corfu.el
@@ -513,6 +513,7 @@ FRAME is the existing frame."
   (when (and (bound-and-true-p exwm--connection)
              (display-graphic-p frame) (frame-parent frame))
     (redisplay t)
+    (set-frame-parameter frame 'delete-before (frame-parent frame))
     (set-frame-parameter frame 'parent-frame nil))
   frame)
 


### PR DESCRIPTION
When in EXWM, the parent frame for any corfu frame is set to nil.  A side effect
of this is that `delete-frame` no longer knows to delete the corfu (child)
frames first.  Since the parent's minibuffer serves as surrogate minibuffer for
the corfu frames, `delete-frame` fails to work as expected.


## Proposed solution
Set the `delete-before` frame parameter of a corfu frame to its parent-frame, just before setting that to nil.  This way
`delete-frame` still knows to delete any corfu (child) frames first.


## Steps to reproduce
0. Optional, delete any existing corfu frames.  (I noticed that doing this makes reproducing the issue more reliable.)
1. Create an additional exwm workspace/frame, e.g. using `exwm-workspace-add`
2. Perform some actions that trigger corfu, so that new corfu frames are created with the current frame's minibuffer as surrogate minibuffer.
3. Try to delete the frame using the `delete-frame` function.  It should complain about an "[a]ttempt to delete a surrogate minibuffer frame".


## Notes
EXWM's [exwm-workspace-delete](https://github.com/emacs-exwm/exwm/blob/main/exwm-workspace.el#L795-L812) works around this issue by transferring any minibuffer surrogates before calling `delete-frame`.  A similar workaround could be applied to functions using `delete-frame`, for example, `tab-bar-move-tab-to-frame`.  But solving it here in corfu using existing mechanisms seems the better solution to me.